### PR TITLE
refac: add retention policy support

### DIFF
--- a/charts/stellar-operator/templates/crd.yaml
+++ b/charts/stellar-operator/templates/crd.yaml
@@ -77,6 +77,12 @@ spec:
                       type: string
                       enum: [Delete, Retain]
                       default: Delete
+                    annotations:
+                      type: object
+                      additionalProperties:
+                        type: string
+                      description: Optional annotations to apply to the PersistentVolumeClaim (useful for storage-class specific parameters like volumeBindingMode)
+                      nullable: true
                 validatorConfig:
                   type: object
                   properties:

--- a/src/controller/resources.rs
+++ b/src/controller/resources.rs
@@ -90,11 +90,19 @@ fn build_pvc(node: &StellarNode) -> PersistentVolumeClaim {
     let mut requests = BTreeMap::new();
     requests.insert("storage".to_string(), Quantity(node.spec.storage.size.clone()));
 
+    // Merge custom annotations from storage config with existing annotations
+    let annotations = node.spec.storage.annotations.clone().unwrap_or_default();
+
     PersistentVolumeClaim {
         metadata: ObjectMeta {
             name: Some(name),
             namespace: node.namespace(),
             labels: Some(labels),
+            annotations: if annotations.is_empty() {
+                None
+            } else {
+                Some(annotations)
+            },
             owner_references: Some(vec![owner_reference(node)]),
             ..Default::default()
         },

--- a/src/crd/types.rs
+++ b/src/crd/types.rs
@@ -2,6 +2,8 @@
 //!
 //! These types are used across the CRD definitions and controller logic.
 
+use std::collections::BTreeMap;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -101,6 +103,10 @@ pub struct StorageConfig {
     /// Retention policy when the node is deleted
     #[serde(default)]
     pub retention_policy: RetentionPolicy,
+    /// Optional annotations to apply to the PersistentVolumeClaim
+    /// Useful for storage-class specific parameters (e.g., volumeBindingMode)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<BTreeMap<String, String>>,
 }
 
 impl Default for StorageConfig {
@@ -109,6 +115,7 @@ impl Default for StorageConfig {
             storage_class: "standard".to_string(),
             size: "100Gi".to_string(),
             retention_policy: RetentionPolicy::default(),
+            annotations: None,
         }
     }
 }


### PR DESCRIPTION
# Changes Made
This PR closes #6 
## 1. Extended StorageConfig struct (`src/crd/types.rs`)

- Added `BTreeMap` import
- Added `annotations: Option<BTreeMap<String, String>>` to `StorageConfig`
- Added documentation for the annotations field
- Updated the `Default` implementation to include `annotations: None`
- Added `#[serde(skip_serializing_if = "Option::is_none")]` to skip serialization when None

## 2. Propagated annotations to PVC (`src/controller/resources.rs`)

- Updated `build_pvc()` to read annotations from `StorageConfig`
- Applied annotations to the PVC metadata when present

## 3. Updated CRD schema (`charts/stellar-operator/templates/crd.yaml`)

- Added `annotations` to the storage properties in the CRD template
- Configured as an optional object with string values

## Features

- Annotations can be specified in the `StorageConfig`
- Annotations are propagated to the created PersistentVolumeClaim
- Useful for storage-class-specific parameters like `volumeBindingMode`
- Optional field with proper defaults

## Example Usage

```yaml
apiVersion: stellar.org/v1alpha1
kind: StellarNode
spec:
  storage:
    storageClass: "standard"
    size: "100Gi"
    annotations:
      volume.kubernetes.io/selected-node: "node-1"
      custom.storage.io/binding-mode: "WaitForFirstConsumer"
```
