### PR TITLE
feat: add support for external postgres database

### DIFF
--- a/src/crd/stellar_node.rs
+++ b/src/crd/stellar_node.rs
@@ -8,8 +8,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::types::{
-    Condition, HorizonConfig, NodeType, ResourceRequirements, RetentionPolicy,
-    SorobanConfig, StellarNetwork, StorageConfig, ValidatorConfig,
+    Condition, ExternalDatabaseConfig, HorizonConfig, NodeType, ResourceRequirements,
+    RetentionPolicy, SorobanConfig, StellarNetwork, StorageConfig, ValidatorConfig,
 };
 
 /// The StellarNode CRD represents a managed Stellar infrastructure node.
@@ -98,6 +98,12 @@ pub struct StellarNodeSpec {
     /// Suspend the node (scale to 0 without deleting resources)
     #[serde(default)]
     pub suspended: bool,
+
+    /// External database configuration for managed Postgres databases
+    /// When provided, database credentials will be fetched from the specified Secret
+    /// and injected as environment variables into the container
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database: Option<ExternalDatabaseConfig>,
 }
 
 fn default_replicas() -> i32 {

--- a/src/crd/types.rs
+++ b/src/crd/types.rs
@@ -187,6 +187,27 @@ pub struct SorobanConfig {
     pub max_events_per_request: u32,
 }
 
+/// External database configuration for managed Postgres databases
+/// Supports RDS, Cloud SQL, CockroachDB, and other managed database services
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalDatabaseConfig {
+    /// Reference to a Kubernetes Secret containing database credentials
+    pub secret_key_ref: SecretKeyRef,
+}
+
+/// Reference to a key within a Kubernetes Secret
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SecretKeyRef {
+    /// Name of the Secret resource
+    pub name: String,
+    /// Key within the Secret to use for the database connection string
+    /// Common keys: "DATABASE_URL", "connection-string", "url"
+    /// For individual components: "host", "port", "database", "user", "password"
+    pub key: String,
+}
+
 fn default_max_events() -> u32 {
     10000
 }


### PR DESCRIPTION

#### Changes
This PR closes #20 
##### New Types (`src/crd/types.rs`)
- **`ExternalDatabaseConfig`**: New struct to configure external database connections
  - `secret_key_ref: SecretKeyRef` - Reference to a Kubernetes Secret containing database credentials

- **`SecretKeyRef`**: New struct to reference a key within a Kubernetes Secret
  - `name: String` - Name of the Secret resource
  - `key: String` - Key within the Secret (e.g., "DATABASE_URL", "connection-string", "url")

##### StellarNodeSpec Updates (`src/crd/stellar_node.rs`)
- Added optional `database: Option<ExternalDatabaseConfig>` field to `StellarNodeSpec`
- When provided, database credentials are automatically fetched from the specified Secret and injected as environment variables

##### Container Environment Variables (`src/controller/resources.rs`)
- Updated `build_container()` function to inject database environment variables from Secrets
- Uses Kubernetes `EnvVarSource` with `SecretKeySelector` to reference Secret keys
- Environment variable names by node type:
  - **Validator nodes**: `DATABASE` environment variable
  - **Horizon nodes**: `DATABASE_URL` environment variable
  - **SorobanRpc nodes**: `DATABASE_URL` environment variable

#### Usage Example

```yaml
apiVersion: stellar.org/v1alpha1
kind: StellarNode
metadata:
  name: my-horizon
  namespace: stellar-nodes
spec:
  nodeType: Horizon
  network: Mainnet
  version: "v21.0.0"
  database:
    secretKeyRef:
      name: "postgres-credentials"  # Pre-created K8s Secret
      key: "DATABASE_URL"            # Key within the Secret
  horizonConfig:
    stellarCoreUrl: "http://stellar-core:11626"
```

#### Benefits
- Support for managed database services (RDS, Cloud SQL, CockroachDB)
- Secure credential management via Kubernetes Secrets
- No need to manage Postgres instances within the cluster
- Production-ready database configurations

#### Files Modified
- `src/crd/types.rs` - Added `ExternalDatabaseConfig` and `SecretKeyRef` types
- `src/crd/stellar_node.rs` - Added `database` field to `StellarNodeSpec`
- `src/controller/resources.rs` - Updated container builder to inject database env vars from Secrets

#### Testing
- ✅ Code compiles successfully with `cargo build`
- ✅ No linter errors
- ✅ Types properly exported and integrated
