### PR TITLE
chore: add github action for cargo audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,18 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   # ==========================================================================
+  # Audit Dependencies
+  # ==========================================================================
+  audit:
+    name: Audit Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  # ==========================================================================
   # Test Suite
   # ==========================================================================
   test:


### PR DESCRIPTION
Add cargo audit to CI pipeline which closes #4 

- Added a new 'Audit Dependencies' job to `.github/workflows/ci.yml`
- Uses `rustsec/audit-check@v2.0.0` action to scan Rust dependencies for security vulnerabilities
- Fails the build on detected vulnerabilities, enhancing security by preventing vulnerable dependencies from being deployed