### PR TITLE
feat: implement kubernetics conditions patterns fr granular status reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arc-swap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,10 +328,10 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -540,7 +549,7 @@ version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -827,6 +836,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1056,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "fs-set-times"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1075,12 @@ dependencies = [
  "rustix 1.1.3",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1311,6 +1345,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1758,6 +1798,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -2577,7 +2623,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2594,7 +2640,7 @@ dependencies = [
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
- "ring",
+ "ring 0.17.14",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
  "rustls-pki-types",
@@ -2714,6 +2760,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
+dependencies = [
+ "pem",
+ "ring 0.16.20",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2821,6 +2879,21 @@ dependencies = [
 
 [[package]]
 name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -2886,7 +2959,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.14",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -2959,9 +3032,9 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring",
+ "ring 0.17.14",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3274,6 +3347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "sptr"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,6 +3370,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
+ "axum-server",
  "base64 0.21.7",
  "chrono",
  "clap",
@@ -3307,8 +3387,9 @@ dependencies = [
  "prometheus-client",
  "rcgen",
  "reqwest",
- "rustls 0.22.4",
+ "rustls 0.23.36",
  "rustls-pemfile",
+ "rustls-pki-types",
  "schemars",
  "serde",
  "serde_json",
@@ -3935,6 +4016,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4480,7 +4567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af5fbb1adaadad70271fe18a3f938741edb2b5178bf2fc164ab20544018626b8"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.4.1",
  "indexmap 2.13.0",
  "wit-parser",
 ]
@@ -4583,7 +4670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1132a122e3d4c77046c7b92d46150e5ee450f29b37a76d3c586e791d15f6c54e"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "shellexpand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ tower-http = { version = "0.5", features = ["trace"], optional = true }
 
 # Metrics
 prometheus-client = { version = "0.22", optional = true }
+once_cell = { version = "1", optional = true }
 axum-server = { version = "0.8.0", features = ["tls-rustls"] }
 rustls-pemfile = "2.2.0"
 rcgen = "0.11"
@@ -69,8 +70,6 @@ wasmtime = { version = "17", optional = true }
 wasmtime-wasi = { version = "17", optional = true }
 
 # Additional crypto for webhook TLS
-rustls = { version = "0.22", optional = true }
-rustls-pemfile = { version = "2", optional = true }
 tokio-rustls = { version = "0.25", optional = true }
 
 # Base64 for Wasm plugin loading
@@ -84,7 +83,7 @@ hex = { version = "0.4", optional = true }
 default = ["rest-api", "metrics"]
 rest-api = ["axum", "tower", "tower-http"]
 metrics = ["prometheus-client", "once_cell"]
-admission-webhook = ["wasmtime", "wasmtime-wasi", "rustls", "rustls-pemfile", "tokio-rustls", "base64", "sha2", "hex", "axum", "tower", "tower-http"]
+admission-webhook = ["wasmtime", "wasmtime-wasi", "tokio-rustls", "base64", "sha2", "hex", "axum", "tower", "tower-http"]
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/controller/conditions.rs
+++ b/src/controller/conditions.rs
@@ -1,0 +1,208 @@
+//! Condition management helpers following Kubernetes API conventions
+
+use chrono::Utc;
+
+use crate::crd::Condition;
+
+/// Standard condition types following Kubernetes conventions
+pub const CONDITION_TYPE_READY: &str = "Ready";
+pub const CONDITION_TYPE_PROGRESSING: &str = "Progressing";
+pub const CONDITION_TYPE_DEGRADED: &str = "Degraded";
+pub const CONDITION_TYPE_AVAILABLE: &str = "Available";
+
+/// Standard condition statuses
+pub const CONDITION_STATUS_TRUE: &str = "True";
+pub const CONDITION_STATUS_FALSE: &str = "False";
+pub const CONDITION_STATUS_UNKNOWN: &str = "Unknown";
+
+/// Update or add a condition to the conditions list
+///
+/// If a condition with the same type exists and has different status/reason/message,
+/// it will be updated with a new transition time. Otherwise, it will be added.
+pub fn set_condition(
+    conditions: &mut Vec<Condition>,
+    type_: &str,
+    status: &str,
+    reason: &str,
+    message: &str,
+) {
+    let now = Utc::now().to_rfc3339();
+
+    if let Some(existing) = conditions.iter_mut().find(|c| c.type_ == type_) {
+        // Update transition time only if status changed
+        let should_update_time = existing.status != status;
+
+        existing.status = status.to_string();
+        existing.reason = reason.to_string();
+        existing.message = message.to_string();
+
+        if should_update_time {
+            existing.last_transition_time = now;
+        }
+    } else {
+        // Add new condition
+        conditions.push(Condition {
+            type_: type_.to_string(),
+            status: status.to_string(),
+            last_transition_time: now,
+            reason: reason.to_string(),
+            message: message.to_string(),
+            observed_generation: None,
+        });
+    }
+}
+
+/// Find a condition by type
+pub fn find_condition<'a>(conditions: &'a [Condition], type_: &str) -> Option<&'a Condition> {
+    conditions.iter().find(|c| c.type_ == type_)
+}
+
+/// Check if a condition is true
+pub fn is_condition_true(conditions: &[Condition], type_: &str) -> bool {
+    find_condition(conditions, type_)
+        .map(|c| c.status == CONDITION_STATUS_TRUE)
+        .unwrap_or(false)
+}
+
+/// Remove a condition by type
+pub fn remove_condition(conditions: &mut Vec<Condition>, type_: &str) {
+    conditions.retain(|c| c.type_ != type_);
+}
+
+/// Create a Ready=True condition
+pub fn ready_condition(reason: &str, message: &str) -> Condition {
+    Condition {
+        type_: CONDITION_TYPE_READY.to_string(),
+        status: CONDITION_STATUS_TRUE.to_string(),
+        last_transition_time: Utc::now().to_rfc3339(),
+        reason: reason.to_string(),
+        message: message.to_string(),
+        observed_generation: None,
+    }
+}
+
+/// Create a Ready=False condition
+pub fn not_ready_condition(reason: &str, message: &str) -> Condition {
+    Condition {
+        type_: CONDITION_TYPE_READY.to_string(),
+        status: CONDITION_STATUS_FALSE.to_string(),
+        last_transition_time: Utc::now().to_rfc3339(),
+        reason: reason.to_string(),
+        message: message.to_string(),
+        observed_generation: None,
+    }
+}
+
+/// Create a Progressing=True condition
+pub fn progressing_condition(reason: &str, message: &str) -> Condition {
+    Condition {
+        type_: CONDITION_TYPE_PROGRESSING.to_string(),
+        status: CONDITION_STATUS_TRUE.to_string(),
+        last_transition_time: Utc::now().to_rfc3339(),
+        reason: reason.to_string(),
+        message: message.to_string(),
+        observed_generation: None,
+    }
+}
+
+/// Create a Progressing=False condition
+pub fn not_progressing_condition(reason: &str, message: &str) -> Condition {
+    Condition {
+        type_: CONDITION_TYPE_PROGRESSING.to_string(),
+        status: CONDITION_STATUS_FALSE.to_string(),
+        last_transition_time: Utc::now().to_rfc3339(),
+        reason: reason.to_string(),
+        message: message.to_string(),
+        observed_generation: None,
+    }
+}
+
+/// Create a Degraded=True condition
+pub fn degraded_condition(reason: &str, message: &str) -> Condition {
+    Condition {
+        type_: CONDITION_TYPE_DEGRADED.to_string(),
+        status: CONDITION_STATUS_TRUE.to_string(),
+        last_transition_time: Utc::now().to_rfc3339(),
+        reason: reason.to_string(),
+        message: message.to_string(),
+        observed_generation: None,
+    }
+}
+
+/// Create a Degraded=False condition
+pub fn not_degraded_condition() -> Condition {
+    Condition {
+        type_: CONDITION_TYPE_DEGRADED.to_string(),
+        status: CONDITION_STATUS_FALSE.to_string(),
+        last_transition_time: Utc::now().to_rfc3339(),
+        reason: "NoIssues".to_string(),
+        message: "No degradation detected".to_string(),
+        observed_generation: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_set_condition_adds_new() {
+        let mut conditions = Vec::new();
+        set_condition(
+            &mut conditions,
+            CONDITION_TYPE_READY,
+            CONDITION_STATUS_TRUE,
+            "AllHealthy",
+            "All checks passed",
+        );
+
+        assert_eq!(conditions.len(), 1);
+        assert_eq!(conditions[0].type_, CONDITION_TYPE_READY);
+        assert_eq!(conditions[0].status, CONDITION_STATUS_TRUE);
+    }
+
+    #[test]
+    fn test_set_condition_updates_existing() {
+        let mut conditions = vec![Condition {
+            type_: CONDITION_TYPE_READY.to_string(),
+            status: CONDITION_STATUS_FALSE.to_string(),
+            last_transition_time: "2024-01-01T00:00:00Z".to_string(),
+            reason: "NotHealthy".to_string(),
+            message: "Node not ready".to_string(),
+            observed_generation: None,
+        }];
+
+        let old_time = conditions[0].last_transition_time.clone();
+        set_condition(
+            &mut conditions,
+            CONDITION_TYPE_READY,
+            CONDITION_STATUS_TRUE,
+            "Healthy",
+            "Node is ready",
+        );
+
+        assert_eq!(conditions.len(), 1);
+        assert_eq!(conditions[0].status, CONDITION_STATUS_TRUE);
+        assert_ne!(conditions[0].last_transition_time, old_time); // Time should change when status changes
+    }
+
+    #[test]
+    fn test_is_condition_true() {
+        let conditions = vec![ready_condition("Healthy", "All good")];
+
+        assert!(is_condition_true(&conditions, CONDITION_TYPE_READY));
+        assert!(!is_condition_true(&conditions, CONDITION_TYPE_DEGRADED));
+    }
+
+    #[test]
+    fn test_find_condition() {
+        let conditions = vec![
+            ready_condition("Healthy", "All good"),
+            progressing_condition("Syncing", "Syncing data"),
+        ];
+
+        assert!(find_condition(&conditions, CONDITION_TYPE_READY).is_some());
+        assert!(find_condition(&conditions, CONDITION_TYPE_PROGRESSING).is_some());
+        assert!(find_condition(&conditions, CONDITION_TYPE_DEGRADED).is_none());
+    }
+}

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1,14 +1,14 @@
 //! Controller module for StellarNode reconciliation
-//!
 //! This module contains the main controller loop, reconciliation logic,
 //! and resource management for Stellar nodes.
 
 mod archive_health;
+pub mod conditions;
 mod finalizers;
-pub mod metrics;
 mod health;
 #[cfg(test)]
 mod health_test;
+pub mod metrics;
 pub mod mtls;
 mod reconciler;
 mod remediation;
@@ -19,4 +19,4 @@ pub use archive_health::{calculate_backoff, check_history_archive_health, Archiv
 pub use finalizers::STELLAR_NODE_FINALIZER;
 pub use health::{check_node_health, HealthCheckResult};
 pub use reconciler::{run_controller, ControllerState};
-pub use remediation::{check_stale_node, can_remediate, RemediationLevel, StaleCheckResult};
+pub use remediation::{can_remediate, check_stale_node, RemediationLevel, StaleCheckResult};

--- a/src/controller/reconciler.rs
+++ b/src/controller/reconciler.rs
@@ -1,5 +1,3 @@
-
-
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -18,32 +16,21 @@ use kube::{
 };
 use tracing::{debug, error, info, instrument, warn};
 
-use crate::controller::archive_health::{
-    calculate_backoff, check_history_archive_health, ArchiveHealthResult,
-};
-use crate::crd::{Condition, NodeType, StellarNode, StellarNodeStatus};
+use crate::crd::{NodeType, StellarNode, StellarNodeStatus};
 use crate::error::{Error, Result};
-
-const ARCHIVE_RETRIES_ANNOTATION: &str = "stellar.org/archive-retries";
-
-use super::finalizers::STELLAR_NODE_FINALIZER;
-use super::health;
-use super::mtls;
-use crate::crd::{
-    AutoscalingConfig, Condition, IngressConfig, NodeType, StellarNode, StellarNodeStatus,
-};
-use crate::error::{Error, Result};
-
-// Constants
-const ARCHIVE_RETRIES_ANNOTATION: &str = "stellar.org/archive-health-retries";
 
 use super::archive_health::{calculate_backoff, check_history_archive_health, ArchiveHealthResult};
+use super::conditions;
 use super::finalizers::STELLAR_NODE_FINALIZER;
 use super::health;
 use super::metrics;
+use super::mtls;
 use super::remediation;
 use super::resources;
 use super::vsl;
+
+// Constants
+const ARCHIVE_RETRIES_ANNOTATION: &str = "stellar.org/archive-health-retries";
 
 /// Shared state for the controller
 pub struct ControllerState {
@@ -178,20 +165,20 @@ async fn apply_stellar_node(
 
     // 1. Core infrastructure (PVC and ConfigMap) always managed by operator
     resources::ensure_pvc(client, node).await?;
-    resources::ensure_config_map(client, node, ctx.enable_mtls).await?;
+    resources::ensure_config_map(client, node, None, ctx.enable_mtls).await?;
     // 2. Handle suspension
     if node.spec.suspended {
         info!("Node {}/{} is suspended, scaling to 0", namespace, name);
 
         resources::ensure_pvc(client, node).await?;
-        resources::ensure_config_map(client, node, None).await?;
-        
+        resources::ensure_config_map(client, node, None, ctx.enable_mtls).await?;
+
         match node.spec.node_type {
             NodeType::Validator => {
-                resources::ensure_statefulset(client, node).await?;
+                resources::ensure_statefulset(client, node, ctx.enable_mtls).await?;
             }
             NodeType::Horizon | NodeType::SorobanRpc => {
-                resources::ensure_deployment(client, node).await?;
+                resources::ensure_deployment(client, node, ctx.enable_mtls).await?;
             }
         }
 
@@ -276,11 +263,6 @@ async fn apply_stellar_node(
 
                         let delay = calculate_backoff(0, None, None);
                         info!(
-                            "Requeuing {}/{} in {:?} (retry attempt {})",
-                            namespace,
-                            name,
-                            delay,
-                            retries + 1
                             "Archive health check failed for {}/{}, requeuing in {:?}",
                             namespace, name, delay
                         );
@@ -315,8 +297,6 @@ async fn apply_stellar_node(
     resources::ensure_pvc(client, node).await?;
     info!("PVC ensured for {}/{}", namespace, name);
 
-    // 2. Create/update the ConfigMap for node configuration
-    resources::ensure_config_map(client, node, ctx.enable_mtls).await?;
     // 2. Handle VSL Fetching for Validators
     let mut quorum_override = None;
     if node.spec.node_type == NodeType::Validator {
@@ -343,7 +323,7 @@ async fn apply_stellar_node(
     }
 
     // 3. Create/update the ConfigMap for node configuration
-    resources::ensure_config_map(client, node, quorum_override.clone()).await?;
+    resources::ensure_config_map(client, node, quorum_override.clone(), ctx.enable_mtls).await?;
     info!("ConfigMap ensured for {}/{}", namespace, name);
 
     // 2.5 Ensure mTLS certificates (if strict mTLS will be handled at rest_api level)
@@ -367,10 +347,10 @@ async fn apply_stellar_node(
 
     // 5. Perform health check to determine if node is ready
     let health_result = health::check_node_health(client, node, ctx.mtls_config.as_ref()).await?;
-    resources::ensure_service(client, node).await?;
+    resources::ensure_service(client, node, ctx.enable_mtls).await?;
 
     // 5. Perform health check to determine if node is ready
-    let health_result = health::check_node_health(client, node).await?;
+    let health_result = health::check_node_health(client, node, ctx.mtls_config.as_ref()).await?;
 
     debug!(
         "Health check result for {}/{}: healthy={}, synced={}, message={}",
@@ -381,14 +361,19 @@ async fn apply_stellar_node(
     if let Some(_quorum) = quorum_override {
         if health_result.healthy {
             // Get pod IP to trigger reload
-            let pod_api: Api<k8s_openapi::api::core::v1::Pod> = Api::namespaced(client.clone(), &namespace);
-            let lp = kube::api::ListParams::default().labels(&format!("app.kubernetes.io/instance={}", name));
+            let pod_api: Api<k8s_openapi::api::core::v1::Pod> =
+                Api::namespaced(client.clone(), &namespace);
+            let lp = kube::api::ListParams::default()
+                .labels(&format!("app.kubernetes.io/instance={}", name));
             if let Ok(pods) = pod_api.list(&lp).await {
                 if let Some(pod) = pods.items.first() {
                     if let Some(status) = &pod.status {
                         if let Some(ip) = &status.pod_ip {
                             if let Err(e) = vsl::trigger_config_reload(ip).await {
-                                warn!("Failed to trigger config-reload for {}/{}: {}", namespace, name, e);
+                                warn!(
+                                    "Failed to trigger config-reload for {}/{}: {}",
+                                    namespace, name, e
+                                );
                             }
                         }
                     }
@@ -734,15 +719,29 @@ async fn update_suspended_status(client: &Client, node: &StellarNode) -> Result<
     let namespace = node.namespace().unwrap_or_else(|| "default".to_string());
     let api: Api<StellarNode> = Api::namespaced(client.clone(), &namespace);
 
-    let condition = Condition {
-        type_: "Ready".to_string(),
-        status: "False".to_string(),
-        last_transition_time: chrono::Utc::now().to_rfc3339(),
-        reason: "NodeSuspended".to_string(),
-        message:
-            "Node is offline - replicas scaled to 0. Service remains active for peer discovery."
-                .to_string(),
-    };
+    let mut conditions = node
+        .status
+        .as_ref()
+        .map(|s| s.conditions.clone())
+        .unwrap_or_default();
+
+    // Set conditions for suspended state
+    conditions::set_condition(
+        &mut conditions,
+        conditions::CONDITION_TYPE_READY,
+        conditions::CONDITION_STATUS_FALSE,
+        "NodeSuspended",
+        "Node is offline - replicas scaled to 0. Service remains active for peer discovery.",
+    );
+    conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_PROGRESSING);
+    conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_DEGRADED);
+
+    // Set observed generation on conditions
+    if let Some(gen) = node.metadata.generation {
+        for condition in &mut conditions {
+            condition.observed_generation = Some(gen);
+        }
+    }
 
     let status = StellarNodeStatus {
         phase: "Suspended".to_string(),
@@ -751,7 +750,7 @@ async fn update_suspended_status(client: &Client, node: &StellarNode) -> Result<
         replicas: 0,
         ready_replicas: 0,
         ledger_sequence: None,
-        conditions: vec![condition],
+        conditions,
         ..Default::default()
     };
 
@@ -767,7 +766,7 @@ async fn update_suspended_status(client: &Client, node: &StellarNode) -> Result<
     Ok(())
 }
 
-/// Update the status subresource of a StellarNode
+/// Update the status subresource of a StellarNode using Kubernetes conditions pattern
 async fn update_status(
     client: &Client,
     node: &StellarNode,
@@ -787,11 +786,192 @@ async fn update_status(
             .and_then(|status| status.observed_generation)
     };
 
+    // Build conditions based on phase
+    let mut conditions = node
+        .status
+        .as_ref()
+        .map(|s| s.conditions.clone())
+        .unwrap_or_default();
+
+    // Map phase to conditions
+    match phase {
+        "Ready" => {
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_READY,
+                conditions::CONDITION_STATUS_TRUE,
+                "AllSubresourcesHealthy",
+                message.unwrap_or("All sub-resources are healthy and operational"),
+            );
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_PROGRESSING,
+                conditions::CONDITION_STATUS_FALSE,
+                "ReconcileComplete",
+                "Reconciliation completed successfully",
+            );
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_DEGRADED,
+                conditions::CONDITION_STATUS_FALSE,
+                "NoIssues",
+                "No degradation detected",
+            );
+        }
+        "Creating" | "Pending" => {
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_READY,
+                conditions::CONDITION_STATUS_FALSE,
+                "Creating",
+                message.unwrap_or("Resources are being created"),
+            );
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_PROGRESSING,
+                conditions::CONDITION_STATUS_TRUE,
+                "Creating",
+                message.unwrap_or("Creating resources"),
+            );
+            conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_DEGRADED);
+        }
+        "Syncing" => {
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_READY,
+                conditions::CONDITION_STATUS_FALSE,
+                "Syncing",
+                message.unwrap_or("Node is syncing with the network"),
+            );
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_PROGRESSING,
+                conditions::CONDITION_STATUS_TRUE,
+                "Syncing",
+                message.unwrap_or("Syncing data"),
+            );
+            conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_DEGRADED);
+        }
+        "Running" => {
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_READY,
+                conditions::CONDITION_STATUS_TRUE,
+                "ResourcesCreated",
+                message.unwrap_or("Resources created successfully"),
+            );
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_PROGRESSING,
+                conditions::CONDITION_STATUS_FALSE,
+                "Complete",
+                "Resource creation complete",
+            );
+            conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_DEGRADED);
+        }
+        "Degraded" => {
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_READY,
+                conditions::CONDITION_STATUS_FALSE,
+                "Degraded",
+                message.unwrap_or("Node is experiencing issues"),
+            );
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_DEGRADED,
+                conditions::CONDITION_STATUS_TRUE,
+                "IssuesDetected",
+                message.unwrap_or("Node is degraded"),
+            );
+            conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_PROGRESSING);
+        }
+        "Failed" => {
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_READY,
+                conditions::CONDITION_STATUS_FALSE,
+                "Failed",
+                message.unwrap_or("Node operation failed"),
+            );
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_DEGRADED,
+                conditions::CONDITION_STATUS_TRUE,
+                "Failed",
+                message.unwrap_or("Operation failed"),
+            );
+            conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_PROGRESSING);
+        }
+        "Remediating" => {
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_READY,
+                conditions::CONDITION_STATUS_FALSE,
+                "Remediating",
+                message.unwrap_or("Auto-remediation in progress"),
+            );
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_PROGRESSING,
+                conditions::CONDITION_STATUS_TRUE,
+                "Remediating",
+                message.unwrap_or("Remediation in progress"),
+            );
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_DEGRADED,
+                conditions::CONDITION_STATUS_TRUE,
+                "Remediating",
+                "Node required remediation",
+            );
+        }
+        "Suspended" => {
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_READY,
+                conditions::CONDITION_STATUS_FALSE,
+                "Suspended",
+                message.unwrap_or("Node is suspended"),
+            );
+            conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_PROGRESSING);
+            conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_DEGRADED);
+        }
+        "Maintenance" => {
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_READY,
+                conditions::CONDITION_STATUS_FALSE,
+                "Maintenance",
+                message.unwrap_or("Node is in maintenance mode"),
+            );
+            conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_PROGRESSING);
+            conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_DEGRADED);
+        }
+        _ => {
+            conditions::set_condition(
+                &mut conditions,
+                conditions::CONDITION_TYPE_READY,
+                conditions::CONDITION_STATUS_UNKNOWN,
+                "Unknown",
+                message.unwrap_or("Status unknown"),
+            );
+        }
+    }
+
+    // Set observed generation on all conditions
+    if let Some(gen) = observed_generation {
+        for condition in &mut conditions {
+            condition.observed_generation = Some(gen);
+        }
+    }
+
     let mut status_patch = serde_json::json!({
         "phase": phase,
         "observedGeneration": observed_generation,
         "replicas": if node.spec.suspended { 0 } else { node.spec.replicas },
         "readyReplicas": ready_replicas,
+        "conditions": conditions,
     });
 
     if let Some(msg) = message {
@@ -819,47 +999,53 @@ async fn update_archive_health_status(
     let namespace = node.namespace().unwrap_or_else(|| "default".to_string());
     let api: Api<StellarNode> = Api::namespaced(client.clone(), &namespace);
 
-    let condition = Condition {
-        type_: "ArchiveHealthCheck".to_string(),
-        status: if result.any_healthy { "True" } else { "False" }.to_string(),
-        last_transition_time: chrono::Utc::now().to_rfc3339(),
-        reason: if result.any_healthy {
-            "ArchiveHealthy"
-        } else {
-            "ArchiveUnreachable"
-        }
-        .to_string(),
-        message: if result.any_healthy {
-            result.summary()
-        } else {
-            format!("{}\n{}", result.summary(), result.error_details())
-        },
-    };
-
     let mut conditions = node
         .status
         .as_ref()
         .map(|s| s.conditions.clone())
         .unwrap_or_default();
 
-    // Update or append the condition
-    if let Some(pos) = conditions
-        .iter()
-        .position(|c| c.type_ == "ArchiveHealthCheck")
-    {
-        conditions[pos] = condition;
+    // Update ArchiveHealthCheck condition
+    let archive_message = if result.any_healthy {
+        result.summary()
     } else {
-        conditions.push(condition);
+        format!("{}\n{}", result.summary(), result.error_details())
+    };
+
+    conditions::set_condition(
+        &mut conditions,
+        "ArchiveHealthCheck",
+        if result.any_healthy {
+            conditions::CONDITION_STATUS_TRUE
+        } else {
+            conditions::CONDITION_STATUS_FALSE
+        },
+        if result.any_healthy {
+            "ArchiveHealthy"
+        } else {
+            "ArchiveUnreachable"
+        },
+        &archive_message,
+    );
+
+    // Set observed generation on conditions
+    if let Some(gen) = node.metadata.generation {
+        for condition in &mut conditions {
+            condition.observed_generation = Some(gen);
+        }
     }
 
-    let patch = serde_json::json!({
-        "status": {
-            "conditions": conditions,
-            "phase": if result.any_healthy { "Creating" } else { "WaitingForArchive" },
-            "message": result.summary()
-        }
+    let mut status_patch = serde_json::json!({
+        "conditions": conditions,
+        "phase": if result.any_healthy { "Creating" } else { "WaitingForArchive" },
     });
 
+    // Don't update observed_generation if archive is unhealthy (to trigger retry)
+    if result.any_healthy {
+        status_patch["observedGeneration"] = serde_json::json!(node.metadata.generation);
+    }
+
+    let patch = serde_json::json!({ "status": status_patch });
     api.patch_status(
         &node.name_any(),
         &PatchParams::apply("stellar-operator"),
@@ -883,24 +1069,68 @@ async fn update_status_with_health(
     let api: Api<StellarNode> = Api::namespaced(client.clone(), &namespace);
 
     // Build conditions based on health check
-    let mut conditions = Vec::new();
+    let mut conditions = node
+        .status
+        .as_ref()
+        .map(|s| s.conditions.clone())
+        .unwrap_or_default();
 
-    // Ready condition
-    let ready_condition = if health.synced {
-        crate::crd::Condition::ready(true, "NodeSynced", "Node is fully synced and operational")
+    // Ready condition based on health status
+    if health.synced {
+        conditions::set_condition(
+            &mut conditions,
+            conditions::CONDITION_TYPE_READY,
+            conditions::CONDITION_STATUS_TRUE,
+            "NodeSynced",
+            "Node is fully synced and operational",
+        );
+        conditions::set_condition(
+            &mut conditions,
+            conditions::CONDITION_TYPE_PROGRESSING,
+            conditions::CONDITION_STATUS_FALSE,
+            "SyncComplete",
+            "Node sync completed",
+        );
+        conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_DEGRADED);
     } else if health.healthy {
-        crate::crd::Condition::ready(false, "NodeSyncing", &health.message)
-    } else {
-        crate::crd::Condition::ready(false, "NodeNotHealthy", &health.message)
-    };
-    conditions.push(ready_condition);
-
-    // Progressing condition
-    if !health.synced && health.healthy {
-        conditions.push(crate::crd::Condition::progressing(
+        conditions::set_condition(
+            &mut conditions,
+            conditions::CONDITION_TYPE_READY,
+            conditions::CONDITION_STATUS_FALSE,
+            "NodeSyncing",
+            &health.message,
+        );
+        conditions::set_condition(
+            &mut conditions,
+            conditions::CONDITION_TYPE_PROGRESSING,
+            conditions::CONDITION_STATUS_TRUE,
             "Syncing",
             &health.message,
-        ));
+        );
+        conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_DEGRADED);
+    } else {
+        conditions::set_condition(
+            &mut conditions,
+            conditions::CONDITION_TYPE_READY,
+            conditions::CONDITION_STATUS_FALSE,
+            "NodeNotHealthy",
+            &health.message,
+        );
+        conditions::set_condition(
+            &mut conditions,
+            conditions::CONDITION_TYPE_DEGRADED,
+            conditions::CONDITION_STATUS_TRUE,
+            "HealthCheckFailed",
+            &health.message,
+        );
+        conditions::remove_condition(&mut conditions, conditions::CONDITION_TYPE_PROGRESSING);
+    }
+
+    // Set observed generation on all conditions
+    if let Some(gen) = node.metadata.generation {
+        for condition in &mut conditions {
+            condition.observed_generation = Some(gen);
+        }
     }
 
     let status = StellarNodeStatus {
@@ -940,14 +1170,23 @@ async fn get_latest_network_ledger(network: &crate::crd::StellarNetwork) -> Resu
         crate::crd::StellarNetwork::Mainnet => "https://horizon.stellar.org",
         crate::crd::StellarNetwork::Testnet => "https://horizon-testnet.stellar.org",
         crate::crd::StellarNetwork::Futurenet => "https://horizon-futurenet.stellar.org",
-        crate::crd::StellarNetwork::Custom(_) => return Err(Error::ConfigError("Custom network not supported for lag calculation yet".to_string())),
+        crate::crd::StellarNetwork::Custom(_) => {
+            return Err(Error::ConfigError(
+                "Custom network not supported for lag calculation yet".to_string(),
+            ))
+        }
     };
 
     let client = reqwest::Client::new();
     let resp = client.get(url).send().await.map_err(Error::HttpError)?;
-    let json: serde_json::Value = resp.json().await.map_err(|e| Error::ConfigError(e.to_string()))?;
-    
-    let ledger = json["history_latest_ledger"].as_u64().ok_or_else(|| Error::ConfigError("Failed to get latest ledger from horizon".to_string()))?;
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| Error::ConfigError(e.to_string()))?;
+
+    let ledger = json["history_latest_ledger"].as_u64().ok_or_else(|| {
+        Error::ConfigError("Failed to get latest ledger from horizon".to_string())
+    })?;
     Ok(ledger)
 }
 

--- a/src/controller/remediation.rs
+++ b/src/controller/remediation.rs
@@ -290,7 +290,10 @@ pub async fn update_remediation_state(
             annotations.insert(LAST_LEDGER_TIME_ANNOTATION.to_string(), now.clone());
             // Reset remediation level on progress
             annotations.insert(REMEDIATION_LEVEL_ANNOTATION.to_string(), "0".to_string());
-            debug!("Ledger progressed to {}, resetting remediation state", ledger);
+            debug!(
+                "Ledger progressed to {}, resetting remediation state",
+                ledger
+            );
         }
     }
 
@@ -334,8 +337,14 @@ mod tests {
     fn test_remediation_level_conversion() {
         assert_eq!(RemediationLevel::from_u8(0), RemediationLevel::None);
         assert_eq!(RemediationLevel::from_u8(1), RemediationLevel::Restart);
-        assert_eq!(RemediationLevel::from_u8(2), RemediationLevel::ClearAndResync);
-        assert_eq!(RemediationLevel::from_u8(99), RemediationLevel::ClearAndResync);
+        assert_eq!(
+            RemediationLevel::from_u8(2),
+            RemediationLevel::ClearAndResync
+        );
+        assert_eq!(
+            RemediationLevel::from_u8(99),
+            RemediationLevel::ClearAndResync
+        );
     }
 
     #[test]

--- a/src/crd/types.rs
+++ b/src/crd/types.rs
@@ -401,6 +401,10 @@ pub struct Condition {
     pub reason: String,
     /// Human-readable message
     pub message: String,
+    /// ObservedGeneration represents the .metadata.generation that the condition was set based upon
+    /// This field is optional and should be set by controllers to track which generation was observed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observed_generation: Option<i64>,
 }
 
 impl Condition {
@@ -412,6 +416,7 @@ impl Condition {
             last_transition_time: chrono::Utc::now().to_rfc3339(),
             reason: reason.to_string(),
             message: message.to_string(),
+            observed_generation: None,
         }
     }
 
@@ -423,7 +428,26 @@ impl Condition {
             last_transition_time: chrono::Utc::now().to_rfc3339(),
             reason: reason.to_string(),
             message: message.to_string(),
+            observed_generation: None,
         }
+    }
+
+    /// Create a new Degraded condition
+    pub fn degraded(reason: &str, message: &str) -> Self {
+        Self {
+            type_: "Degraded".to_string(),
+            status: "True".to_string(),
+            last_transition_time: chrono::Utc::now().to_rfc3339(),
+            reason: reason.to_string(),
+            message: message.to_string(),
+            observed_generation: None,
+        }
+    }
+
+    /// Set the observed generation for this condition
+    pub fn with_observed_generation(mut self, generation: i64) -> Self {
+        self.observed_generation = Some(generation);
+        self
     }
 }
 

--- a/src/webhook/server.rs
+++ b/src/webhook/server.rs
@@ -21,8 +21,8 @@ use tracing::{error, info, instrument, warn};
 
 use super::runtime::WasmRuntime;
 use super::types::{
-    Operation, PluginConfig, PluginExecutionResult, PluginMetadata,
-    UserInfo, ValidationInput, ValidationOutput,
+    Operation, PluginConfig, PluginExecutionResult, PluginMetadata, UserInfo, ValidationInput,
+    ValidationOutput,
 };
 use crate::crd::StellarNode;
 use crate::error::{Error, Result};
@@ -124,22 +124,25 @@ impl WebhookServer {
 
     /// Configure TLS
     pub fn with_tls(mut self, cert_path: String, key_path: String) -> Self {
-        self.tls_config = Some(TlsConfig { cert_path, key_path });
+        self.tls_config = Some(TlsConfig {
+            cert_path,
+            key_path,
+        });
         self
     }
 
     /// Add a plugin
     pub async fn add_plugin(&self, config: PluginConfig) -> Result<()> {
         // Decode base64 wasm_binary
-        let wasm_binary_str = config.wasm_binary.as_ref().ok_or_else(|| {
-            Error::PluginError("Plugin wasm_binary is required".to_string())
-        })?;
-        
-        let wasm_bytes = base64::Engine::decode(
-            &base64::engine::general_purpose::STANDARD,
-            wasm_binary_str,
-        ).map_err(|e| Error::PluginError(format!("Invalid base64 wasm_binary: {}", e)))?;
-        
+        let wasm_binary_str = config
+            .wasm_binary
+            .as_ref()
+            .ok_or_else(|| Error::PluginError("Plugin wasm_binary is required".to_string()))?;
+
+        let wasm_bytes =
+            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, wasm_binary_str)
+                .map_err(|e| Error::PluginError(format!("Invalid base64 wasm_binary: {}", e)))?;
+
         // Load into runtime
         self.runtime
             .load_plugin(&wasm_bytes, config.metadata.clone())
@@ -147,10 +150,10 @@ impl WebhookServer {
 
         // Add to plugins list
         let mut plugins = self.plugins.write().await;
-        
+
         // Remove existing plugin with same name
         plugins.retain(|p| p.metadata.name != config.metadata.name);
-        
+
         plugins.push(config);
 
         Ok(())
@@ -237,7 +240,7 @@ impl WebhookServer {
     pub async fn start(self, addr: SocketAddr) -> Result<()> {
         // Check TLS config before moving self into Arc
         let has_tls = self.tls_config.is_some();
-        
+
         let state = Arc::new(self);
 
         let app = Router::new()
@@ -248,7 +251,10 @@ impl WebhookServer {
             .route("/mutate", post(mutate_handler))
             .route("/plugins", get(list_plugins_handler))
             .route("/plugins", post(add_plugin_handler))
-            .route("/plugins/:name", axum::routing::delete(remove_plugin_handler))
+            .route(
+                "/plugins/:name",
+                axum::routing::delete(remove_plugin_handler),
+            )
             .with_state(state);
 
         info!("Starting webhook server on {}", addr);
@@ -285,15 +291,21 @@ async fn health_handler(State(state): State<Arc<WebhookServer>>) -> impl IntoRes
 async fn ready_handler(State(state): State<Arc<WebhookServer>>) -> impl IntoResponse {
     let plugins = state.plugins.read().await;
     if plugins.is_empty() {
-        (StatusCode::SERVICE_UNAVAILABLE, Json(HealthResponse {
-            status: "no plugins loaded".to_string(),
-            plugins_loaded: 0,
-        }))
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(HealthResponse {
+                status: "no plugins loaded".to_string(),
+                plugins_loaded: 0,
+            }),
+        )
     } else {
-        (StatusCode::OK, Json(HealthResponse {
-            status: "ready".to_string(),
-            plugins_loaded: plugins.len(),
-        }))
+        (
+            StatusCode::OK,
+            Json(HealthResponse {
+                status: "ready".to_string(),
+                plugins_loaded: plugins.len(),
+            }),
+        )
     }
 }
 
@@ -308,17 +320,16 @@ async fn validate_handler(
             error!("Failed to parse admission request: {}", e);
             return (
                 StatusCode::BAD_REQUEST,
-                Json(AdmissionResponse::invalid(format!(
-                    "Invalid admission request: {}",
-                    e
-                ))
-                .into_review()),
+                Json(
+                    AdmissionResponse::invalid(format!("Invalid admission request: {}", e))
+                        .into_review(),
+                ),
             );
         }
     };
 
     let req: AdmissionRequest<StellarNode> = request;
-    
+
     // Build validation input
     let input = build_validation_input(&req);
 
@@ -329,7 +340,11 @@ async fn validate_handler(
     let mut response = if result.allowed {
         AdmissionResponse::from(&req)
     } else {
-        AdmissionResponse::from(&req).deny(result.message.unwrap_or_else(|| "Validation failed".to_string()))
+        AdmissionResponse::from(&req).deny(
+            result
+                .message
+                .unwrap_or_else(|| "Validation failed".to_string()),
+        )
     };
 
     // Add warnings if any
@@ -352,7 +367,7 @@ async fn mutate_handler(
 ) -> impl IntoResponse {
     // For now, mutation is not supported - just pass through
     let request: Result<AdmissionRequest<StellarNode>, _> = review.try_into();
-    
+
     match request {
         Ok(req) => {
             let response = AdmissionResponse::from(&req);
@@ -362,11 +377,10 @@ async fn mutate_handler(
             error!("Failed to parse admission request: {}", e);
             (
                 StatusCode::BAD_REQUEST,
-                Json(AdmissionResponse::invalid(format!(
-                    "Invalid admission request: {}",
-                    e
-                ))
-                .into_review()),
+                Json(
+                    AdmissionResponse::invalid(format!("Invalid admission request: {}", e))
+                        .into_review(),
+                ),
             )
         }
     }
@@ -397,7 +411,7 @@ async fn add_plugin_handler(
         &base64::engine::general_purpose::STANDARD,
         &request.wasm_binary,
     );
-    
+
     let config = PluginConfig {
         metadata: request.metadata,
         wasm_binary: Some(wasm_binary_base64),
@@ -411,7 +425,10 @@ async fn add_plugin_handler(
     };
 
     match state.add_plugin(config).await {
-        Ok(_) => (StatusCode::CREATED, Json(serde_json::json!({"status": "created"}))),
+        Ok(_) => (
+            StatusCode::CREATED,
+            Json(serde_json::json!({"status": "created"})),
+        ),
         Err(e) => {
             error!("Failed to add plugin: {}", e);
             (
@@ -427,7 +444,10 @@ async fn remove_plugin_handler(
     axum::extract::Path(name): axum::extract::Path<String>,
 ) -> impl IntoResponse {
     match state.remove_plugin(&name).await {
-        Ok(_) => (StatusCode::OK, Json(serde_json::json!({"status": "removed"}))),
+        Ok(_) => (
+            StatusCode::OK,
+            Json(serde_json::json!({"status": "removed"})),
+        ),
         Err(e) => {
             error!("Failed to remove plugin: {}", e);
             (
@@ -456,8 +476,14 @@ fn build_validation_input(req: &AdmissionRequest<StellarNode>) -> ValidationInpu
 
     ValidationInput {
         operation,
-        object: req.object.as_ref().map(|o| serde_json::to_value(o).unwrap_or_default()),
-        old_object: req.old_object.as_ref().map(|o| serde_json::to_value(o).unwrap_or_default()),
+        object: req
+            .object
+            .as_ref()
+            .map(|o| serde_json::to_value(o).unwrap_or_default()),
+        old_object: req
+            .old_object
+            .as_ref()
+            .map(|o| serde_json::to_value(o).unwrap_or_default()),
         namespace: req.namespace.clone().unwrap_or_default(),
         name: req.name.clone(),
         user_info,
@@ -482,9 +508,7 @@ mod base64_serde {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        STANDARD
-            .decode(&s)
-            .map_err(serde::de::Error::custom)
+        STANDARD.decode(&s).map_err(serde::de::Error::custom)
     }
 }
 


### PR DESCRIPTION
## Description 

This PR implements the standard Kubernetes Conditions pattern for the StellarNode CRD, replacing the simple phase-based status reporting with granular condition-based status information. This follows the [Kubernetes API conventions for typical status properties](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Fixed build errors and more 

All unit tests passing 
Condition helper tests verify proper transition time tracking
Status derivation tests ensure backward compatibility
Build completes successfully with only expected deprecation warnings

<img width="824" height="308" alt="image" src="https://github.com/user-attachments/assets/73ab7021-ffc5-4091-9a6e-dad08e7fd4d0" />

Closes #15 