### PR TITLE
docs: add CHANGELOG.md following Keep a Changelog conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-02-19
+
+### Added
+
+- `StellarNode` CRD with Validator support
+- Basic Controller logic with `kube-rs`
+- Helm Chart for easy deployment
+- CI/CD Pipeline with GitHub Actions and Docker builds
+- Auto-Sync Health Checks for Horizon and Soroban RPC nodes
+- kubectl-stellar plugin for node management
+
+[Unreleased]: https://github.com/OtowoOrg/Stellar-K8s/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/OtowoOrg/Stellar-K8s/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ See [kubectl-plugin.md](docs/kubectl-plugin.md) for complete documentation.
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details on our development process, coding standards, and how to submit pull requests.
 
+See also our [CHANGELOG](CHANGELOG.md) for a list of changes in each release.
+
 ---
 
 ## Roadmap


### PR DESCRIPTION
## Summary
This PR adds a CHANGELOG.md file following the Keep a Changelog conventions as requested in issue #158.

## Changes Made

### Created CHANGELOG.md
- Added [Unreleased] section for tracking future changes
- Added [0.1.0] section documenting initial Phase 1 features:
  - StellarNode CRD with Validator support
  - Basic Controller logic with kube-rs
  - Helm Chart for easy deployment
  - CI/CD Pipeline with GitHub Actions and Docker builds
  - Auto-Sync Health Checks for Horizon and Soroban RPC nodes
  - kubectl-stellar plugin for node management

### Updated README.md
- Added link to CHANGELOG from the Contributing section

## Acceptance Criteria Met

- [x] CHANGELOG.md created at repo root
- [x] Follows Keep a Changelog format
- [x] Added [Unreleased] and [0.1.0] sections
- [x] Documented initial features
- [x] Linked from README.md

## Testing

No code changes - documentation only. The CHANGELOG follows the standard format and links are ready for when the upstream repo creates releases.