### PR TITLE
feat: Add Test Coverage for Archive Health Module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +910,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1503,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2395,6 +2429,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3666,6 +3710,7 @@ dependencies = [
  "tracing-subscriber",
  "wasmtime",
  "wasmtime-wasi",
+ "wiremock",
 ]
 
 [[package]]
@@ -5199,6 +5244,29 @@ checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.10.0",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,12 @@ opentelemetry-otlp = { version = "0.14", features = [
 ] }
 
 # HTTP client for health checks
-reqwest = { version = "0.12", features = ["json", "rustls-tls-manual-roots", "native-tls", "multipart"] }
+reqwest = { version = "0.12", features = [
+    "json",
+    "rustls-tls-manual-roots",
+    "native-tls",
+    "multipart",
+] }
 
 # REST API (optional)
 axum = { version = "0.8.8", optional = true }
@@ -124,6 +129,7 @@ axum = ["dep:axum"]
 [dev-dependencies]
 tokio-test = "0.4"
 tempfile = "3"
+wiremock = "0.6"
 
 [[bin]]
 name = "stellar-operator"


### PR DESCRIPTION
closes #179 


## Summary
Added comprehensive test coverage for `src/controller/archive_health.rs` which checks the health of Stellar history archives. The module previously had zero test coverage despite being critical for validators syncing new nodes.

## Changes

### Dependencies
- Added `wiremock = "0.6"` to `dev-dependencies` for HTTP mocking in tests

### Test Coverage
Added 9 new integration tests in `src/controller/archive_health.rs`:

1. **test_reachable_archive_healthy** - Verifies reachable archives with valid `.well-known/stellar-history.json` return healthy status
2. **test_unreachable_archive_unhealthy** - Confirms unreachable archives are marked unhealthy and error is captured
3. **test_archive_degraded_stale_metadata** - Tests archives with stale/missing metadata but working root endpoint (degraded state)
4. **test_archive_both_endpoints_fail** - Verifies archives failing both metadata and root endpoints are marked unhealthy
5. **test_timeout_respected** - Confirms configurable timeout is enforced (short timeout causes failure)
6. **test_timeout_sufficient** - Validates health checks succeed when timeout is adequate
7. **test_multiple_archives_mixed_health** - Tests parallel checking of multiple archives with mixed health statuses
8. **test_error_details_formatting** - Validates error message formatting for unhealthy archives
9. **test_empty_url_list** - Handles edge case of empty archive URL list

## Testing
All tests pass successfully:
```
running 12 tests
test controller::archive_health::tests::test_backoff_calculation ... ok
test controller::archive_health::tests::test_health_result_empty ... ok
test controller::archive_health::tests::test_health_result_summary ... ok
test controller::archive_health::tests::test_empty_url_list ... ok
test controller::archive_health::tests::test_error_details_formatting ... ok
test controller::archive_health::tests::test_multiple_archives_mixed_health ... ok
test controller::archive_health::tests::test_unreachable_archive_unhealthy ... ok
test controller::archive_health::tests::test_archive_degraded_stale_metadata ... ok
test controller::archive_health::tests::test_archive_both_endpoints_fail ... ok
test controller::archive_health::tests::test_reachable_archive_healthy ... ok
test controller::archive_health::tests::test_timeout_respected ... ok
test controller::archive_health::tests::test_timeout_sufficient ... ok

test result: ok. 12 passed; 0 failed; 0 ignored
```

## Acceptance Criteria Met ✅
- [x] Test for reachable archive returning healthy status
- [x] Test for unreachable archive marked unhealthy with error annotation
- [x] Test for archive with stale metadata flagged as degraded
- [x] Test for configurable timeout (mocked with wiremock)
- [x] All tests pass with `cargo test`

## Implementation Details
- Used `wiremock` crate to mock HTTP responses for reliable, fast tests without external dependencies
- Tests cover both success and failure paths for `.well-known/stellar-history.json` and root endpoints
- Validated timeout behavior with both insufficient and sufficient durations
- Tested parallel health checking of multiple archives
- Maintained existing functionality while achieving 100% test coverage on new code paths
