### PR TITLE
feat(operator): implement auto-scaling read-only replica pools

### DIFF
--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -25,6 +25,7 @@ pub mod mtls;
 pub mod peer_discovery;
 #[cfg(test)]
 mod peer_discovery_test;
+pub mod read_pool;
 mod reconciler;
 #[cfg(test)]
 mod reconciler_test;
@@ -32,7 +33,7 @@ mod remediation;
 #[cfg(test)]
 mod remediation_test;
 mod resources;
-mod traffic;
+pub mod traffic;
 #[cfg(test)]
 mod traffic_test;
 mod vsl;

--- a/src/controller/reconciler.rs
+++ b/src/controller/reconciler.rs
@@ -691,6 +691,20 @@ pub(crate) async fn apply_stellar_node(
     )
     .await?;
 
+    // 5b. Read-Only Replica Pools
+    apply_or_emit(
+        ctx,
+        node,
+        ActionType::Update,
+        "Read-Only Replica Pool",
+        async {
+            crate::controller::read_pool::ensure_read_pool(client, node, ctx.enable_mtls).await?;
+            crate::controller::traffic::reconcile_traffic_routing(client, node).await?;
+            Ok(())
+        },
+    )
+    .await?;
+
     // 6. Autoscaling and Monitoring
     apply_or_emit(
         ctx,

--- a/src/crd/mod.rs
+++ b/src/crd/mod.rs
@@ -3,7 +3,7 @@
 //! This module defines the Kubernetes CRDs for managing Stellar infrastructure.
 
 mod cnpg;
-mod read_replica;
+pub mod read_replica;
 mod stellar_node;
 mod types;
 


### PR DESCRIPTION
## Description
This PR implements auto-scaling pools of Read-Only Stellar nodes. This feature allows users to configure dedicated replica pools for read-traffic, separate from the primary validator/node workloads.

### Key Changes
- **CRD Update**: Added `read_replica_config` to `StellarNodeSpec` to control pool size, resources, and routing strategy.
- **Controller Logic**: Integrated `ensure_read_pool` and `reconcile_traffic_routing` into the main reconciliation loop.
- **Traffic Management**: Support for weighted load-balancing and shard-balancing strategies (RoundRobin, ConsistentHashing, LeastConnection).
- **Tooling Support**: Updated the `kubectl-stellar` plugin and Captive Core configuration builder to respect the new spec structure.

### Verification Results
- All unit and doc-tests passed (`cargo test`).
- Verified CRD validation logic for both validator and horizon node types.
- Fixed derivable implementation warnings in `src/crd/read_replica.rs`.
- Code formatted with `cargo fmt`.

### Checklist
- [x] Implementation plan approved
- [x] Compilation successful (`cargo check`)
- [x] Tests passing (`cargo test`)
- [x] Linting clean (`cargo clippy`)
- [x] Code formatted (`cargo fmt`)

#78 
