### PR TITLE
feat: Add Docker Compose development environment (#315)

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,30 @@
+# Development Dockerfile with cargo-watch for hot-reloading
+FROM rust:1.93-bookworm
+
+WORKDIR /app
+
+# Install cargo-watch for hot-reloading
+RUN cargo install cargo-watch
+
+# Install kubectl for K8s API interaction
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && chmod +x kubectl \
+    && mv kubectl /usr/local/bin/
+
+# Copy dependency manifests for caching
+COPY Cargo.toml Cargo.lock ./
+COPY build.rs ./
+
+# Create dummy source to cache dependencies
+RUN mkdir -p src && \
+    echo "fn main() {}" > src/main.rs && \
+    cargo build && \
+    rm -rf src
+
+# Copy actual source code
+COPY . .
+
+# Expose ports
+EXPOSE 8080 9090
+
+CMD ["cargo", "watch", "-x", "run -- run --namespace stellar-system --dry-run"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test fmt lint clean docker-build install-crd apply-samples dev-setup ci-local benchmark benchmark-webhook benchmark-webhook-health benchmark-webhook-compare benchmark-webhook-save benchmark-all run-dev
+.PHONY: help build test fmt lint clean docker-build install-crd apply-samples dev-setup ci-local benchmark benchmark-webhook benchmark-webhook-health benchmark-webhook-compare benchmark-webhook-save benchmark-all run-dev compose-up compose-dev compose-down compose-logs
 
 # Default target
 .DEFAULT_GOAL := help
@@ -124,3 +124,20 @@ bundle-build: ## Build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 all: ci-local docker-build ## Full build pipeline
+
+# Docker Compose targets
+compose-up: ## Start Docker Compose development environment
+	@echo "→ Starting Docker Compose environment..."
+	@docker-compose up -d
+	@echo "✓ Environment started. Use 'make compose-logs' to view logs"
+
+compose-dev: ## Start Docker Compose with hot-reloading
+	@echo "→ Starting Docker Compose with hot-reloading..."
+	@docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
+
+compose-down: ## Stop Docker Compose environment
+	@echo "→ Stopping Docker Compose environment..."
+	@docker-compose down
+
+compose-logs: ## View Docker Compose logs
+	@docker-compose logs -f stellar-operator

--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ Stellar-K8s follows the **Operator Pattern**, extending Kubernetes with a `Stell
 
 Get a Testnet node running in under 5 minutes.
 
+### Option 1: Docker Compose (No K8s Required)
+
+Perfect for local development and testing without a full Kubernetes cluster:
+
+```bash
+# Start the development environment
+make compose-up
+
+# View logs
+make compose-logs
+
+# Stop the environment
+make compose-down
+```
+
+See the [Docker Compose Quickstart Guide](docs/docker-compose-quickstart.md) for detailed instructions.
+
+### Option 2: Kubernetes Cluster
+
 ### 1. Install the Operator via Helm
 
 ```bash

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,37 @@
+# Docker Compose Development Overlay
+# Extends docker-compose.yml with hot-reloading for active development
+version: '3.8'
+
+services:
+  # Override stellar-operator with development build and hot-reload
+  stellar-operator-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: ["cargo", "watch", "-x", "run -- run --namespace stellar-system --dry-run"]
+    environment:
+      - RUST_LOG=debug,stellar_k8s=trace
+      - OPERATOR_NAMESPACE=stellar-system
+      - DRY_RUN=true
+      - KUBECONFIG=/kubeconfig/kubeconfig.yaml
+      - RUST_BACKTRACE=1
+    volumes:
+      - ./:/app:cached
+      - ./kubeconfig:/kubeconfig:ro
+      - ./config:/etc/stellar-operator:ro
+      - cargo-cache:/usr/local/cargo/registry
+      - target-cache:/app/target
+    depends_on:
+      k3s:
+        condition: service_healthy
+    networks:
+      - stellar-dev
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+
+volumes:
+  cargo-cache:
+    driver: local
+  target-cache:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,61 @@
+# Docker Compose Development Environment for Stellar-K8s
+# Provides a local development setup without requiring a full K8s cluster
+version: '3.8'
+
+services:
+  # K3s lightweight Kubernetes in Docker
+  k3s:
+    image: rancher/k3s:v1.28.5-k3s1
+    command: server --disable traefik --disable servicelb --disable metrics-server
+    privileged: true
+    environment:
+      - K3S_TOKEN=stellar-dev-token
+      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+      - K3S_KUBECONFIG_MODE=666
+    volumes:
+      - k3s-server:/var/lib/rancher/k3s
+      - ./kubeconfig:/output
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "6443:6443"  # Kubernetes API
+      - "8080:8080"  # Operator REST API
+      - "9090:9090"  # Operator Metrics
+    tmpfs:
+      - /run
+      - /var/run
+    networks:
+      - stellar-dev
+    healthcheck:
+      test: ["CMD", "kubectl", "get", "nodes"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Stellar Operator in dry-run mode
+  stellar-operator:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: ["stellar-operator", "run", "--namespace", "stellar-system", "--dry-run"]
+    environment:
+      - RUST_LOG=info,stellar_k8s=debug
+      - OPERATOR_NAMESPACE=stellar-system
+      - DRY_RUN=true
+      - KUBECONFIG=/kubeconfig/kubeconfig.yaml
+    volumes:
+      - ./kubeconfig:/kubeconfig:ro
+      - ./config:/etc/stellar-operator:ro
+    depends_on:
+      k3s:
+        condition: service_healthy
+    networks:
+      - stellar-dev
+    restart: unless-stopped
+
+volumes:
+  k3s-server:
+    driver: local
+
+networks:
+  stellar-dev:
+    driver: bridge

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,10 @@ struct RunArgs {
     /// Example: --dump-config
     #[arg(long)]
     dump_config: bool,
+
+    /// Run preflight checks and exit without starting the operator
+    #[arg(long, env = "PREFLIGHT_ONLY")]
+    preflight_only: bool,
 }
 
 impl RunArgs {
@@ -137,9 +141,6 @@ impl RunArgs {
         }
         Ok(())
     }
-    /// Run preflight checks and exit without starting the operator
-    #[arg(long, env = "PREFLIGHT_ONLY")]
-    preflight_only: bool,
 }
 
 #[derive(Parser, Debug)]


### PR DESCRIPTION
- Add docker-compose.yml with K3s and operator in dry-run mode
- Add docker-compose.dev.yml overlay with cargo-watch hot-reloading
- Add Dockerfile.dev for development builds
- Update Makefile with compose-up, compose-dev, compose-down targets
- Update README.md with Docker Compose quick start option
- Fix syntax error in src/main.rs (preflight_only field placement)

Closes #315