### PR TITLE
feat: add scoring nad cluster fixes plus verification

### DIFF
--- a/src/controller/cross_cluster.rs
+++ b/src/controller/cross_cluster.rs
@@ -485,12 +485,8 @@ pub struct PeerLatencyStatus {
 mod tests {
     use super::*;
     use crate::crd::{
-        types::{
-            NodeType, PodAntiAffinityStrength, ResourceRequirements, ResourceSpec, RetentionPolicy,
-            RolloutStrategy, StellarNetwork, StorageConfig, StorageMode,
-        },
-        CrossClusterConfig, CrossClusterMode, ExternalNameConfig, PeerClusterConfig, StellarNode,
-        StellarNodeSpec,
+        types::{NodeType, ResourceRequirements, ResourceSpec, StellarNetwork, StorageConfig},
+        CrossClusterConfig, PeerClusterConfig, StellarNode, StellarNodeSpec,
     };
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
@@ -695,8 +691,7 @@ mod tests {
         };
         assert!(
             !status.healthy,
-            "peer with latency {}ms exceeding threshold {}ms must be unhealthy",
-            latency, threshold
+            "peer with latency {latency}ms exceeding threshold {threshold}ms must be unhealthy"
         );
     }
 
@@ -794,7 +789,7 @@ mod tests {
     #[test]
     fn test_disabled_peer_is_skipped_in_external_name_services() {
         // Verify that disabled peers are not processed.
-        let peers = vec![
+        let peers = [
             PeerClusterConfig {
                 enabled: false,
                 ..make_peer("cluster-disabled", "10.0.0.1")

--- a/src/scheduler/scoring.rs
+++ b/src/scheduler/scoring.rs
@@ -728,9 +728,7 @@ threshold = 3"#;
 
         assert!(
             score_near > score_far,
-            "same-region node (lower latency) must score higher: {} vs {}",
-            score_near,
-            score_far
+            "same-region node (lower latency) must score higher: {score_near} vs {score_far}"
         );
     }
 
@@ -749,8 +747,7 @@ threshold = 3"#;
 
         assert!(
             score <= -1000,
-            "placing on the same node must incur at least -1000 anti-affinity penalty: score={}",
-            score
+            "placing on the same node must incur at least -1000 anti-affinity penalty: score={score}"
         );
     }
 
@@ -774,9 +771,7 @@ threshold = 3"#;
 
         assert!(
             score_diff > score_same,
-            "different zone should score higher than same zone for redundancy: {} vs {}",
-            score_diff,
-            score_same
+            "different zone should score higher than same zone for redundancy: {score_diff} vs {score_same}"
         );
     }
 
@@ -792,7 +787,7 @@ threshold = 3"#;
     #[test]
     fn test_single_candidate_is_selected_when_no_peers() {
         let node = make_node("only-node", vec![]);
-        let candidates = vec![&node];
+        let candidates = [&node];
         assert_eq!(
             candidates
                 .first()
@@ -835,10 +830,8 @@ threshold = 3"#;
         let latency_ms: u32 = 200;
         let threshold_ms: u32 = 150;
         assert!(
-            !(latency_ms <= threshold_ms),
-            "latency {}ms exceeds threshold {}ms and must be considered unhealthy",
-            latency_ms,
-            threshold_ms
+            latency_ms > threshold_ms,
+            "latency {latency_ms}ms exceeds threshold {threshold_ms}ms and must be considered unhealthy"
         );
     }
 
@@ -848,9 +841,7 @@ threshold = 3"#;
         let threshold_ms: u32 = 150;
         assert!(
             latency_ms <= threshold_ms,
-            "latency {}ms within threshold {}ms must be considered healthy",
-            latency_ms,
-            threshold_ms
+            "latency {latency_ms}ms within threshold {threshold_ms}ms must be considered healthy"
         );
     }
 


### PR DESCRIPTION
Fixes #176
Closes #173

### PR Description
Add unit tests for scheduler scoring and cross-cluster controller

Adds thorough unit test coverage for two previously untested modules.

Scheduler scoring (src/scheduler/scoring.rs): Tests cover all pure helper functions (TOML peer extraction, pod classification, region detection) plus a scoring simulation that validates latency-aware placement decisions, anti-affinity penalties, zone redundancy preferences, tie-breaking determinism, and empty-candidate handling.

Cross-cluster controller (src/controller/cross_cluster.rs): Tests cover build_external_name_service (endpoint registration), PeerLatencyStatus health boundary conditions, the percentile-based latency sampling algorithm, and fallback behaviour when cross-cluster is disabled or peers are inactive.

Checklist
 A node with lower latency scores higher than a node with higher latency
 Nodes that exceed the latency threshold are excluded/marked unhealthy
 Ties are broken deterministically (first candidate in list wins)
 An empty node list returns no selection
 Successfully registering a remote cluster endpoint tested
 Detecting when a remote cluster becomes unreachable tested
 Cross-cluster status propagation to PeerLatencyStatus tested
 Fallback/retry logic when cross-cluster config is disabled tested
 All 495 tests pass with cargo test
