### PR TITLE
feat : implement reconciliation error counter

### DIFF
--- a/src/controller/metrics.rs
+++ b/src/controller/metrics.rs
@@ -4,6 +4,7 @@
 //! The `/metrics` endpoint (when built with `--features metrics`) exports the following metrics:
 //! - `stellar_reconcile_duration_seconds` (histogram): reconcile duration labeled by controller.
 //! - `stellar_reconcile_errors_total` (counter): reconcile errors labeled by controller and kind.
+//! - `stellar_operator_reconcile_errors_total` (counter): operator reconcile errors labeled by controller and kind.
 //! - `stellar_node_ledger_sequence` (gauge): ledger sequence labeled by namespace/name/node_type/network.
 //! - `stellar_node_ingestion_lag` (gauge): ingestion lag labeled by namespace/name/node_type/network.
 //! - `stellar_horizon_tps` (gauge): Horizon TPS labeled by namespace/name/node_type/network.
@@ -145,6 +146,10 @@ pub static RECONCILE_DURATION_SECONDS: Lazy<Family<ReconcileLabels, Histogram>> 
 pub static RECONCILE_ERRORS_TOTAL: Lazy<Family<ErrorLabels, Counter<u64, AtomicU64>>> =
     Lazy::new(Family::default);
 
+/// Counter tracking operator-level reconcile errors
+pub static OPERATOR_RECONCILE_ERRORS_TOTAL: Lazy<Family<ErrorLabels, Counter<u64, AtomicU64>>> =
+    Lazy::new(Family::default);
+
 /// Soroban-specific metrics
 /// Histogram tracking Wasm execution time in microseconds
 pub static WASM_EXECUTION_DURATION_MICROSECONDS: Lazy<Family<SorobanLabels, Histogram>> =
@@ -231,6 +236,12 @@ pub static REGISTRY: Lazy<Registry> = Lazy::new(|| {
         "stellar_reconcile_errors_total",
         "Total number of reconcile errors",
         RECONCILE_ERRORS_TOTAL.clone(),
+    );
+
+    registry.register(
+        "stellar_operator_reconcile_errors_total",
+        "Total number of operator reconcile errors",
+        OPERATOR_RECONCILE_ERRORS_TOTAL.clone(),
     );
 
     registry.register(
@@ -389,6 +400,15 @@ pub fn inc_reconcile_error(controller: &str, kind: &str) {
         kind: kind.to_string(),
     };
     RECONCILE_ERRORS_TOTAL.get_or_create(&labels).inc();
+}
+
+/// Increment the operator reconcile error counter.
+pub fn inc_operator_reconcile_error(controller: &str, kind: &str) {
+    let labels = ErrorLabels {
+        controller: controller.to_string(),
+        kind: kind.to_string(),
+    };
+    OPERATOR_RECONCILE_ERRORS_TOTAL.get_or_create(&labels).inc();
 }
 
 /// Increment reactive status updates counter
@@ -943,5 +963,47 @@ mod tests {
         assert_eq!(labels.name, "soroban-prod");
         assert_eq!(labels.network, "mainnet");
         assert!(labels.contract_id.starts_with("CDLZFC"));
+    }
+
+    #[test]
+    fn test_inc_operator_reconcile_error() {
+        // Test that incrementing operator reconcile error doesn't panic
+        inc_operator_reconcile_error("stellarnode", "kube");
+        inc_operator_reconcile_error("stellarnode", "validation");
+        inc_operator_reconcile_error("stellarnode", "config");
+        // Function should not panic
+    }
+
+    #[test]
+    fn test_operator_reconcile_errors_total_registered() {
+        // Verify the new metric is registered in the global registry
+        let _registry = &*REGISTRY;
+        // Access the metric to ensure it's initialized
+        let labels = ErrorLabels {
+            controller: "stellarnode".to_string(),
+            kind: "test".to_string(),
+        };
+        let counter = OPERATOR_RECONCILE_ERRORS_TOTAL.get_or_create(&labels);
+        counter.inc();
+        // If this doesn't panic, the metric is properly registered and functional
+    }
+
+    #[test]
+    fn test_operator_reconcile_error_labels() {
+        // Test that error labels are created correctly for operator errors
+        let labels = ErrorLabels {
+            controller: "stellarnode".to_string(),
+            kind: "unknown".to_string(),
+        };
+
+        assert_eq!(labels.controller, "stellarnode");
+        assert_eq!(labels.kind, "unknown");
+
+        // Test with different error kinds
+        inc_operator_reconcile_error("stellarnode", "kube");
+        inc_operator_reconcile_error("stellarnode", "validation");
+        inc_operator_reconcile_error("stellarnode", "config");
+        inc_operator_reconcile_error("stellarnode", "unknown");
+        // Function should not panic with various error kinds
     }
 }

--- a/src/controller/reconciler.rs
+++ b/src/controller/reconciler.rs
@@ -128,7 +128,7 @@ impl ControllerState {
 ///
 /// ```rust,no_run
 /// use std::sync::Arc;
-/// use std::sync::atomic::AtomicBool;
+/// use std::sync::atomic::{AtomicBool, AtomicU64};
 /// use stellar_k8s::controller::{ControllerState, run_controller};
 /// use kube::Client;
 ///
@@ -148,6 +148,8 @@ impl ControllerState {
 ///             instance: None,
 ///         },
 ///         operator_config: Arc::new(Default::default()),
+///         reconcile_id_counter: AtomicU64::new(0),
+///         last_reconcile_success: Arc::new(AtomicU64::new(0)),
 ///     });
 ///     run_controller(state).await?;
 ///     Ok(())
@@ -418,14 +420,20 @@ async fn reconcile(obj: Arc<StellarNode>, ctx: Arc<ControllerState>) -> Result<A
 
     let node_name_for_span = node_name.clone();
     let namespace_for_span = namespace.clone();
+    let resource_version = obj
+        .metadata
+        .resource_version
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
 
     // Attach per-reconcile structured fields so every log event during reconciliation
-    // can be correlated in JSON logs (node_name/namespace/reconcile_id).
+    // can be correlated in JSON logs (node_name/namespace/reconcile_id/resource_version).
     let _reconcile_span = info_span!(
         "reconcile_attempt",
         node_name = %node_name_for_span,
         namespace = %namespace_for_span,
-        reconcile_id = %reconcile_id
+        reconcile_id = %reconcile_id,
+        resource_version = %resource_version
     );
     let _reconcile_enter = _reconcile_span.enter();
 
@@ -470,6 +478,7 @@ async fn reconcile(obj: Arc<StellarNode>, ctx: Arc<ControllerState>) -> Result<A
                 _ => "unknown",
             };
             metrics::inc_reconcile_error("stellarnode", kind);
+            metrics::inc_operator_reconcile_error("stellarnode", kind);
         } else {
             // Record successful reconciliation timestamp
             let now = std::time::SystemTime::now()
@@ -2556,12 +2565,18 @@ pub(crate) fn error_policy(
 
     let node_name_for_span = node_name.clone();
     let namespace_for_span = namespace.clone();
+    let resource_version = node
+        .metadata
+        .resource_version
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
 
     let _error_span = info_span!(
         "reconcile_error",
         node_name = %node_name_for_span,
         namespace = %namespace_for_span,
-        reconcile_id = %reconcile_id
+        reconcile_id = %reconcile_id,
+        resource_version = %resource_version
     );
     let _enter = _error_span.enter();
 


### PR DESCRIPTION
This PR improves operator observability by adding a new counter metric, `stellar_operator_reconcile_errors_total`, and enriching reconciliation logs with `resource_version`.

## Changes

### Added reconciliation error counter

- Created `OPERATOR_RECONCILE_ERRORS_TOTAL` in `metrics.rs`
- Added `inc_operator_reconcile_error()` helper for counter increments
- Registered the metric in the global Prometheus registry
- Wired the counter into reconciliation error paths in `reconciler.rs`
- Updated module-level documentation to include the new metric

### Added `resource_version` to reconciliation logs

- Extracted `resource_version` from object metadata in `reconcile()`
- Included `resource_version` in the `reconcile_attempt` tracing span
- Included `resource_version` in the `reconcile_error` span within `error_policy()`
- Updated comments to reflect the logging enhancement

### Added tests

- `test_inc_operator_reconcile_error()`
- `test_operator_reconcile_errors_total_registered()`
- `test_operator_reconcile_error_labels()`

## Motivation

This change makes reconciliation failures easier to monitor and investigate.

The new counter provides a dedicated signal for total reconciliation failures, while the additional `resource_version` field in tracing spans improves debugging by making it easier to correlate failures with a specific object version.

## Scope

This PR adds observability improvements only:
- metrics
- structured logging
- tests
- documentation

It does not change reconciliation logic or alter controller behavior.

closes #360 
closes #368 