### PR TITLE
feat: update_check_in_interval Function

### DIFF
--- a/docs/mtls-guide.md
+++ b/docs/mtls-guide.md
@@ -1,0 +1,217 @@
+# mTLS Setup and Certificate Rotation Guide
+
+This guide explains how to enable mTLS for the operator, how node certificates are provisioned, and how to rotate certificates safely.
+
+## Scope
+
+This repository currently manages mTLS in two places:
+
+- Operator REST API mTLS (server cert + CA, with automatic server cert rotation)
+- StellarNode workload certs (per-node client cert secret, recreated on reconcile if missing)
+
+## Certificate and Secret Model
+
+When mTLS is enabled, the operator manages these Kubernetes Secrets in the operator namespace:
+
+- `stellar-operator-ca`
+  - `tls.crt`: CA certificate
+  - `tls.key`: CA private key
+- `stellar-operator-server-cert`
+  - `tls.crt`: operator REST API server certificate
+  - `tls.key`: operator REST API server private key
+  - `ca.crt`: CA certificate used for client trust
+
+For each `StellarNode`, the operator also creates:
+
+- `<node-name>-client-cert`
+  - `tls.crt`
+  - `tls.key`
+  - `ca.crt`
+
+The node workloads mount this secret at `/etc/stellar/tls` and use:
+
+- `/etc/stellar/tls/tls.crt`
+- `/etc/stellar/tls/tls.key`
+- `/etc/stellar/tls/ca.crt`
+
+## Prerequisites
+
+- Running Kubernetes cluster
+- Operator deployed in a namespace (examples below use `stellar-system`)
+- `kubectl` access to that namespace
+- REST API enabled (default in the chart)
+
+## Enable mTLS
+
+## Option A: CLI / local run
+
+Run the operator with mTLS enabled:
+
+```bash
+stellar-operator run --namespace stellar-system --enable-mtls
+```
+
+Equivalent environment variable:
+
+```bash
+ENABLE_MTLS=true
+```
+
+## Option B: Kubernetes deployment
+
+If your deployment does not already pass `--enable-mtls`, add it to the operator container args.
+
+Example patch:
+
+```bash
+kubectl -n stellar-system patch deployment stellar-operator \
+  --type='json' \
+  -p='[
+    {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--enable-mtls"}
+  ]'
+```
+
+If your deployment name differs, replace `stellar-operator` with the actual deployment name.
+
+## Verify mTLS Provisioning
+
+Check CA and server secrets:
+
+```bash
+kubectl -n stellar-system get secret stellar-operator-ca
+kubectl -n stellar-system get secret stellar-operator-server-cert
+```
+
+Check data keys:
+
+```bash
+kubectl -n stellar-system get secret stellar-operator-server-cert -o jsonpath='{.data}'
+```
+
+You should see `tls.crt`, `tls.key`, and `ca.crt`.
+
+Check node certificate secret (for a node named `validator-1`):
+
+```bash
+kubectl -n stellar-system get secret validator-1-client-cert
+```
+
+## How Rotation Works
+
+## Operator server certificate rotation
+
+- The operator checks server cert expiry hourly.
+- Rotation threshold is controlled by `CERT_ROTATION_THRESHOLD_DAYS`.
+- Default threshold is `30` days.
+- When rotation happens, the operator reloads in-memory TLS config without full process restart.
+
+Set custom threshold:
+
+```bash
+kubectl -n stellar-system set env deployment/stellar-operator CERT_ROTATION_THRESHOLD_DAYS=14
+```
+
+## Node certificate behavior
+
+- Per-node certs are ensured on reconcile.
+- Existing node cert secrets are not proactively rotated by a timer.
+- If a `<node-name>-client-cert` secret is missing, reconcile recreates it.
+
+## Manual Rotation Runbooks
+
+## Rotate operator server certificate now
+
+Delete only the server cert secret; keep CA unchanged:
+
+```bash
+kubectl -n stellar-system delete secret stellar-operator-server-cert
+```
+
+Then restart operator pod (or wait for reconciliation/startup logic to recreate it):
+
+```bash
+kubectl -n stellar-system rollout restart deployment/stellar-operator
+kubectl -n stellar-system rollout status deployment/stellar-operator
+```
+
+## Rotate a node certificate now
+
+For node `validator-1`:
+
+```bash
+kubectl -n stellar-system delete secret validator-1-client-cert
+```
+
+Trigger reconcile by touching the node annotation:
+
+```bash
+kubectl -n stellar-system annotate stellarnode validator-1 mtls.rotate-ts="$(date +%s)" --overwrite
+```
+
+Confirm secret recreation:
+
+```bash
+kubectl -n stellar-system get secret validator-1-client-cert
+```
+
+## Rotate the CA (full trust rollover)
+
+CA rotation invalidates all certificates issued by the old CA. Plan a maintenance window.
+
+Suggested sequence:
+
+1. Scale down workloads that depend on strict mutual trust.
+2. Delete CA, server cert, and node cert secrets.
+3. Restart operator so it recreates CA/server cert.
+4. Trigger reconcile for all `StellarNode` resources so node certs are recreated.
+5. Scale workloads back up and verify health.
+
+Commands:
+
+```bash
+kubectl -n stellar-system delete secret stellar-operator-ca stellar-operator-server-cert
+kubectl -n stellar-system delete secret -l app.kubernetes.io/managed-by=stellar-operator
+kubectl -n stellar-system rollout restart deployment/stellar-operator
+kubectl -n stellar-system rollout status deployment/stellar-operator
+```
+
+If your node cert secrets do not carry a reliable label selector, delete them by explicit name (`<node>-client-cert`) instead.
+
+## Validation Checklist
+
+- Operator pod is `Running` and ready.
+- `stellar-operator-ca` exists with `tls.crt` and `tls.key`.
+- `stellar-operator-server-cert` exists with `tls.crt`, `tls.key`, `ca.crt`.
+- Each managed `StellarNode` has `<node-name>-client-cert`.
+- Node pods have mounted `/etc/stellar/tls` volume.
+- REST API and node endpoints continue to pass readiness/liveness checks.
+
+## Troubleshooting
+
+## Missing `ca.crt` / `tls.crt` / `tls.key`
+
+- Recreate the affected secret by deleting it and triggering reconcile.
+- Check operator logs for certificate generation errors.
+
+```bash
+kubectl -n stellar-system logs deploy/stellar-operator --tail=200
+```
+
+## Rotation not happening
+
+- Verify `ENABLE_MTLS=true`.
+- Verify `CERT_ROTATION_THRESHOLD_DAYS` value.
+- Confirm the running leader instance is healthy (rotation runs on the leader path).
+
+## Client trust failures after CA changes
+
+- Ensure all leaf certs were reissued from the new CA.
+- Ensure consumers trust the new `ca.crt`.
+- Restart components holding old TLS material in memory.
+
+## Security Recommendations
+
+- Restrict read access to Secrets (`stellar-operator-ca`, server cert, node certs).
+- Back up CA material in a secure secrets system before planned rotation.
+- Prefer short cert lifetimes and scheduled rotation windows.
+- Audit access to TLS secrets and operator logs.

--- a/src/controller/metrics.rs
+++ b/src/controller/metrics.rs
@@ -2,6 +2,7 @@
 //!
 //! # Exported metrics
 //! The `/metrics` endpoint (when built with `--features metrics`) exports the following metrics:
+//! - `reconcile_duration_seconds` (histogram): reconcile duration labeled by controller.
 //! - `stellar_reconcile_duration_seconds` (histogram): reconcile duration labeled by controller.
 //! - `stellar_reconcile_errors_total` (counter): reconcile errors labeled by controller and kind.
 //! - `stellar_node_ledger_sequence` (gauge): ledger sequence labeled by namespace/name/node_type/network.
@@ -141,6 +142,17 @@ pub static RECONCILE_DURATION_SECONDS: Lazy<Family<ReconcileLabels, Histogram>> 
     Family::new_with_constructor(reconcile_histogram)
 });
 
+/// Histogram tracking reconcile duration (seconds) under the non-prefixed metric name.
+pub static RAW_RECONCILE_DURATION_SECONDS: Lazy<Family<ReconcileLabels, Histogram>> =
+    Lazy::new(|| {
+        fn reconcile_histogram() -> Histogram {
+            // 1ms .. ~32s across 16 buckets.
+            Histogram::new(exponential_buckets(0.001, 2.0, 16))
+        }
+
+        Family::new_with_constructor(reconcile_histogram)
+    });
+
 /// Counter tracking reconcile errors
 pub static RECONCILE_ERRORS_TOTAL: Lazy<Family<ErrorLabels, Counter<u64, AtomicU64>>> =
     Lazy::new(Family::default);
@@ -220,6 +232,12 @@ pub static DR_DRILL_TIME_TO_RECOVERY_MS: Lazy<Family<DRDrillLabels, Gauge<i64, A
 /// Global metrics registry
 pub static REGISTRY: Lazy<Registry> = Lazy::new(|| {
     let mut registry = Registry::default();
+
+    registry.register(
+        "reconcile_duration_seconds",
+        "Duration of reconcile loops in seconds",
+        RAW_RECONCILE_DURATION_SECONDS.clone(),
+    );
 
     registry.register(
         "stellar_reconcile_duration_seconds",
@@ -377,6 +395,9 @@ pub fn observe_reconcile_duration_seconds(controller: &str, seconds: f64) {
     let labels = ReconcileLabels {
         controller: controller.to_string(),
     };
+    RAW_RECONCILE_DURATION_SECONDS
+        .get_or_create(&labels)
+        .observe(seconds);
     RECONCILE_DURATION_SECONDS
         .get_or_create(&labels)
         .observe(seconds);

--- a/src/controller/resources.rs
+++ b/src/controller/resources.rs
@@ -135,28 +135,37 @@ pub async fn ensure_pvc(client: &Client, node: &StellarNode, dry_run: bool) -> R
     let api: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), &namespace);
     let name = resource_name(node, "data");
 
-    // Dynamic resolution of storage class for local mode
-    let mut resolved_storage_class = node.spec.storage.storage_class.clone();
+    // Dynamic resolution of storage class for local mode.
+    let mut has_local_path = false;
+    let mut has_local_storage = false;
+    if node.spec.storage.mode == crate::crd::types::StorageMode::Local
+        && node.spec.storage.storage_class.is_empty()
+    {
+        let sc_api: Api<k8s_openapi::api::storage::v1::StorageClass> = Api::all(client.clone());
+        has_local_path = sc_api.get("local-path").await.is_ok();
+        has_local_storage = sc_api.get("local-storage").await.is_ok();
+    }
+    let resolved_storage_class =
+        resolve_pvc_storage_class(node, has_local_path, has_local_storage);
     if node.spec.storage.mode == crate::crd::types::StorageMode::Local
         && resolved_storage_class.is_empty()
     {
-        // Fallback or auto-detect `local-path`
-        let sc_api: Api<k8s_openapi::api::storage::v1::StorageClass> = Api::all(client.clone());
-        if sc_api.get("local-path").await.is_ok() {
-            resolved_storage_class = "local-path".to_string();
-        } else if sc_api.get("local-storage").await.is_ok() {
-            resolved_storage_class = "local-storage".to_string();
-        } else {
-            // Let it fall through, the standard validation might complain if it's strictly empty and local
-            warn!("Local StorageMode requested but no storageClass provided and local-path/local-storage auto-detection failed.");
-        }
+        warn!(
+            "Local StorageMode requested but no storageClass provided and local-path/local-storage auto-detection failed."
+        );
     }
 
     let pvc = build_pvc(node, resolved_storage_class);
 
     match api.get(&name).await {
-        Ok(_existing) => {
-            info!("PVC {} already exists", name);
+        Ok(existing) => {
+            if pvc_needs_update(&existing, &pvc) {
+                info!("Updating PVC {}", name);
+                api.patch(&name, &patch_params(dry_run), &Patch::Apply(&pvc))
+                    .await?;
+            } else {
+                info!("PVC {} already exists and is up-to-date", name);
+            }
         }
         Err(kube::Error::Api(e)) if e.code == 404 => {
             info!("Creating PVC {}", name);
@@ -166,6 +175,33 @@ pub async fn ensure_pvc(client: &Client, node: &StellarNode, dry_run: bool) -> R
     }
 
     Ok(())
+}
+
+fn resolve_pvc_storage_class(
+    node: &StellarNode,
+    has_local_path: bool,
+    has_local_storage: bool,
+) -> String {
+    let resolved_storage_class = node.spec.storage.storage_class.clone();
+    if node.spec.storage.mode != crate::crd::types::StorageMode::Local
+        || !resolved_storage_class.is_empty()
+    {
+        return resolved_storage_class;
+    }
+
+    if has_local_path {
+        "local-path".to_string()
+    } else if has_local_storage {
+        "local-storage".to_string()
+    } else {
+        String::new()
+    }
+}
+
+fn pvc_needs_update(existing: &PersistentVolumeClaim, desired: &PersistentVolumeClaim) -> bool {
+    existing.spec != desired.spec
+        || existing.metadata.labels != desired.metadata.labels
+        || existing.metadata.annotations != desired.metadata.annotations
 }
 
 fn build_pvc(node: &StellarNode, storage_class_name: String) -> PersistentVolumeClaim {
@@ -2431,4 +2467,144 @@ pub(crate) fn build_statefulset_for_test(
 #[cfg(test)]
 pub(crate) fn build_service_for_test(node: &StellarNode) -> k8s_openapi::api::core::v1::Service {
     build_service(node, false)
+}
+
+#[cfg(test)]
+mod ensure_pvc_tests {
+    use super::{build_pvc, pvc_needs_update, resolve_pvc_storage_class};
+    use crate::crd::{
+        types::{ResourceRequirements, ResourceSpec, StorageConfig, StorageMode},
+        NodeType, StellarNetwork, StellarNode, StellarNodeSpec,
+    };
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+    fn test_node() -> StellarNode {
+        StellarNode {
+            metadata: ObjectMeta {
+                name: Some("test-node".to_string()),
+                namespace: Some("stellar-system".to_string()),
+                uid: Some("abc-123".to_string()),
+                ..Default::default()
+            },
+            spec: StellarNodeSpec {
+                node_type: NodeType::Validator,
+                network: StellarNetwork::Testnet,
+                version: "v21.0.0".to_string(),
+                history_mode: Default::default(),
+                resources: ResourceRequirements {
+                    requests: ResourceSpec {
+                        cpu: "500m".to_string(),
+                        memory: "1Gi".to_string(),
+                    },
+                    limits: ResourceSpec {
+                        cpu: "2".to_string(),
+                        memory: "4Gi".to_string(),
+                    },
+                },
+                storage: StorageConfig::default(),
+                validator_config: None,
+                horizon_config: None,
+                soroban_config: None,
+                replicas: 1,
+                min_available: None,
+                max_unavailable: None,
+                suspended: false,
+                alerting: false,
+                database: None,
+                managed_database: None,
+                autoscaling: None,
+                vpa_config: None,
+                ingress: None,
+                load_balancer: None,
+                global_discovery: None,
+                cross_cluster: None,
+                strategy: Default::default(),
+                maintenance_mode: false,
+                network_policy: None,
+                dr_config: None,
+                pod_anti_affinity: Default::default(),
+                topology_spread_constraints: None,
+                cve_handling: None,
+                snapshot_schedule: None,
+                restore_from_snapshot: None,
+                read_replica_config: None,
+                read_pool_endpoint: None,
+                db_maintenance_config: None,
+                oci_snapshot: None,
+                service_mesh: None,
+                forensic_snapshot: None,
+                resource_meta: None,
+            },
+            status: None,
+        }
+    }
+
+    #[test]
+    fn resolves_storage_class_with_explicit_value() {
+        let mut node = test_node();
+        node.spec.storage.mode = StorageMode::Local;
+        node.spec.storage.storage_class = "fast-ssd".to_string();
+
+        let resolved = resolve_pvc_storage_class(&node, true, true);
+        assert_eq!(resolved, "fast-ssd");
+    }
+
+    #[test]
+    fn resolves_storage_class_to_local_path_for_local_mode() {
+        let mut node = test_node();
+        node.spec.storage.mode = StorageMode::Local;
+        node.spec.storage.storage_class.clear();
+
+        let resolved = resolve_pvc_storage_class(&node, true, false);
+        assert_eq!(resolved, "local-path");
+    }
+
+    #[test]
+    fn resolves_storage_class_to_local_storage_when_path_missing() {
+        let mut node = test_node();
+        node.spec.storage.mode = StorageMode::Local;
+        node.spec.storage.storage_class.clear();
+
+        let resolved = resolve_pvc_storage_class(&node, false, true);
+        assert_eq!(resolved, "local-storage");
+    }
+
+    #[test]
+    fn resolves_storage_class_to_empty_when_no_local_class_found() {
+        let mut node = test_node();
+        node.spec.storage.mode = StorageMode::Local;
+        node.spec.storage.storage_class.clear();
+
+        let resolved = resolve_pvc_storage_class(&node, false, false);
+        assert!(resolved.is_empty());
+    }
+
+    #[test]
+    fn build_pvc_uses_resolved_storage_class() {
+        let node = test_node();
+        let pvc = build_pvc(&node, "gp3".to_string());
+
+        assert_eq!(
+            pvc.spec.as_ref().and_then(|s| s.storage_class_name.as_deref()),
+            Some("gp3")
+        );
+    }
+
+    #[test]
+    fn pvc_update_detects_storage_class_change() {
+        let node = test_node();
+        let existing = build_pvc(&node, "standard".to_string());
+        let desired = build_pvc(&node, "gp3".to_string());
+
+        assert!(pvc_needs_update(&existing, &desired));
+    }
+
+    #[test]
+    fn pvc_update_skips_when_specs_match() {
+        let node = test_node();
+        let existing = build_pvc(&node, "standard".to_string());
+        let desired = build_pvc(&node, "standard".to_string());
+
+        assert!(!pvc_needs_update(&existing, &desired));
+    }
 }


### PR DESCRIPTION
Implemented a multi-part update covering PVC reliability, observability, and security documentation.

Description:
- Added and hardened PVC reconciliation logic so existing PVCs are now updated when desired state changes (not only created on first reconcile), including storage-class-aware behavior for local mode.
- Added focused unit tests for `ensure_pvc` logic to validate storage class resolution and update detection across scenarios.
- Added a new Prometheus histogram metric `reconcile_duration_seconds` in the metrics module.
- Ensured reconciliation durations are observed in the main reconcile loop via the existing duration observation path.
- Added a dedicated mTLS operations guide at mtls-guide.md with setup, verification, and certificate rotation runbooks (operator certs, node certs, and CA rollover guidance).

Validation:
- Targeted new PVC tests pass.
- Metrics-feature build check passes.

Issue numbers covered:

- Closes #347 and Closes #350: Add unit tests for `ensure_pvc` logic (PVC creation/update behavior across storage classes).
- Closes #351: Document mTLS setup in a dedicated guide.
- Closes #352: Add `reconcile_duration_seconds` histogram metric and observe reconcile durations in the main loop.