### PR TITLE
feat :  implement resource limits for different node types

### DIFF
--- a/docs/resource-limits.md
+++ b/docs/resource-limits.md
@@ -1,0 +1,358 @@
+# Resource Limits for Stellar Node Types
+
+This document provides recommended CPU and memory resource limits for different Stellar node types managed by the Stellar-K8s operator.
+
+## Overview
+
+The operator supports three node types, each with different resource requirements:
+
+- **Validator**: Full consensus node running Stellar Core
+- **Horizon**: REST API server for ledger queries
+- **Soroban RPC**: Smart contract interaction node
+
+Resource requirements vary based on network (Mainnet vs Testnet), workload, and operational requirements.
+
+## Recommended Resource Limits
+
+### Validator Nodes
+
+Validator nodes participate in consensus and require consistent, predictable resources.
+
+#### Production (Mainnet)
+
+```yaml
+spec:
+  nodeType: Validator
+  resources:
+    requests:
+      cpu: "2"
+      memory: "4Gi"
+    limits:
+      cpu: "4"
+      memory: "8Gi"
+```
+
+**Rationale:**
+
+- CPU: Validators need consistent CPU for consensus participation and transaction validation
+- Memory: Ledger state and in-memory operations require 4-8Gi
+- Disk I/O: High IOPS required for ledger writes (use SSD-backed storage)
+
+#### Development/Testnet
+
+```yaml
+spec:
+  nodeType: Validator
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+```
+
+**Rationale:**
+
+- Lower transaction volume allows reduced resource allocation
+- Suitable for testing and development environments
+
+### Horizon Nodes
+
+Horizon nodes serve API requests and can be horizontally scaled.
+
+#### Production (Mainnet)
+
+```yaml
+spec:
+  nodeType: Horizon
+  resources:
+    requests:
+      cpu: "1"
+      memory: "2Gi"
+    limits:
+      cpu: "4"
+      memory: "8Gi"
+```
+
+**Rationale:**
+
+- CPU: API request handling and database queries
+- Memory: Query result caching and connection pooling
+- Scalability: Use HPA (Horizontal Pod Autoscaler) for traffic spikes
+
+#### Development/Testnet
+
+```yaml
+spec:
+  nodeType: Horizon
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+```
+
+**Rationale:**
+
+- Lower request volume in test environments
+- Minimal resource footprint for development
+
+### Soroban RPC Nodes
+
+Soroban RPC nodes handle smart contract simulation and submission.
+
+#### Production (Mainnet)
+
+```yaml
+spec:
+  nodeType: SorobanRpc
+  resources:
+    requests:
+      cpu: "2"
+      memory: "4Gi"
+    limits:
+      cpu: "8"
+      memory: "16Gi"
+```
+
+**Rationale:**
+
+- CPU: Contract execution and Wasm runtime require significant compute
+- Memory: Captive Core instance + contract state + VM memory
+- Higher limits accommodate complex contract simulations
+
+#### Development/Testnet
+
+```yaml
+spec:
+  nodeType: SorobanRpc
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "2Gi"
+    limits:
+      cpu: "4"
+      memory: "8Gi"
+```
+
+**Rationale:**
+
+- Reduced contract complexity in test environments
+- Suitable for development and testing
+
+## Resource Precedence
+
+The operator applies resources in the following order of precedence:
+
+1. **StellarNode spec.resources** (highest priority)
+2. **Helm chart defaultResources** (from values.yaml)
+3. **Hardcoded operator defaults** (fallback)
+
+### Example: Custom Resources
+
+```yaml
+apiVersion: stellar.org/v1alpha1
+kind: StellarNode
+metadata:
+  name: my-validator
+spec:
+  nodeType: Validator
+  network: Mainnet
+  resources:
+    requests:
+      cpu: "3"
+      memory: "6Gi"
+    limits:
+      cpu: "6"
+      memory: "12Gi"
+```
+
+## Storage Requirements
+
+### Validator
+
+- **Mainnet**: 500Gi - 1Ti (growing ~50Gi/year)
+- **Testnet**: 100Gi - 200Gi
+- **Storage Class**: SSD-backed (high IOPS required)
+
+### Horizon
+
+- **Mainnet**: 1Ti - 2Ti (full history)
+- **Testnet**: 200Gi - 500Gi
+- **Storage Class**: SSD-backed (database performance)
+
+### Soroban RPC
+
+- **Mainnet**: 500Gi - 1Ti (Captive Core + contract state)
+- **Testnet**: 100Gi - 200Gi
+- **Storage Class**: SSD-backed (Wasm execution performance)
+
+## Autoscaling Recommendations
+
+### Horizon (Recommended)
+
+```yaml
+spec:
+  nodeType: Horizon
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+```
+
+### Soroban RPC (Optional)
+
+```yaml
+spec:
+  nodeType: SorobanRpc
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 75
+```
+
+### Validator (Not Recommended)
+
+Validators should NOT use autoscaling as they:
+
+- Require stable identity for consensus
+- Use StatefulSets (not Deployments)
+- Need consistent peer connections
+
+## Monitoring and Tuning
+
+### Key Metrics
+
+Monitor these metrics to tune resource limits:
+
+1. **CPU Utilization**
+   - Target: 60-80% average utilization
+   - Alert: >90% sustained for 5+ minutes
+
+2. **Memory Usage**
+   - Target: 70-85% of limit
+   - Alert: >95% or OOMKilled events
+
+3. **Disk I/O**
+   - Target: <80% IOPS capacity
+   - Alert: I/O wait >20%
+
+### Prometheus Queries
+
+```promql
+# CPU utilization by node
+rate(container_cpu_usage_seconds_total{pod=~"stellar-.*"}[5m])
+
+# Memory usage by node
+container_memory_working_set_bytes{pod=~"stellar-.*"}
+
+# Disk I/O wait
+rate(node_disk_io_time_seconds_total[5m])
+```
+
+## Performance Tuning
+
+### CPU Optimization
+
+1. **Validator**: Set CPU requests = limits (guaranteed QoS)
+2. **Horizon**: Allow burstable CPU for traffic spikes
+3. **Soroban**: Higher limits for complex contract execution
+
+### Memory Optimization
+
+1. **Validator**: Set memory requests = limits (avoid OOM)
+2. **Horizon**: Configure connection pool sizes based on memory
+3. **Soroban**: Allocate extra memory for Wasm VM overhead
+
+### Example: Guaranteed QoS for Validator
+
+```yaml
+spec:
+  nodeType: Validator
+  resources:
+    requests:
+      cpu: "4"
+      memory: "8Gi"
+    limits:
+      cpu: "4" # Same as requests = Guaranteed QoS
+      memory: "8Gi" # Same as requests = Guaranteed QoS
+```
+
+## Cost Optimization
+
+### Development Environments
+
+Use minimal resources and spot instances:
+
+```yaml
+spec:
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "1"
+      memory: "2Gi"
+```
+
+### Production Environments
+
+Balance cost and reliability:
+
+1. **Validators**: Use reserved instances (predictable cost)
+2. **Horizon**: Use autoscaling with spot instances for burst capacity
+3. **Soroban**: Mix on-demand and spot instances
+
+## Troubleshooting
+
+### OOMKilled Pods
+
+**Symptoms**: Pods restart with exit code 137
+
+**Solutions**:
+
+1. Increase memory limits
+2. Check for memory leaks in application logs
+3. Review database query efficiency (Horizon)
+
+### CPU Throttling
+
+**Symptoms**: High latency, slow response times
+
+**Solutions**:
+
+1. Increase CPU limits
+2. Check for inefficient queries or operations
+3. Consider horizontal scaling (Horizon/Soroban)
+
+### Disk I/O Bottlenecks
+
+**Symptoms**: High I/O wait, slow ledger writes
+
+**Solutions**:
+
+1. Upgrade to faster storage class (SSD/NVMe)
+2. Increase IOPS provisioning
+3. Consider local SSD for validators
+
+## References
+
+- [Kubernetes Resource Management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [Stellar Core Configuration](https://developers.stellar.org/docs/run-core-node)
+- [Horizon Configuration](https://developers.stellar.org/docs/run-api-server)
+- [Soroban RPC Configuration](https://developers.stellar.org/docs/data/rpc)
+
+## Hardcoded Defaults
+
+The operator provides these fallback defaults when no configuration is specified:
+
+| Node Type | CPU Request | Memory Request | CPU Limit | Memory Limit |
+| --------- | ----------- | -------------- | --------- | ------------ |
+| Validator | 500m        | 1Gi            | 2         | 4Gi          |
+| Horizon   | 250m        | 512Mi          | 2         | 4Gi          |
+| Soroban   | 500m        | 2Gi            | 4         | 8Gi          |
+
+These defaults are defined in `src/controller/operator_config.rs::hardcoded_defaults()`.

--- a/src/controller/operator_config.rs
+++ b/src/controller/operator_config.rs
@@ -402,4 +402,107 @@ reconciler:
         assert_eq!(cfg.reconciler.max_backoff, 600);
         assert!(!cfg.reconciler.enable_jitter);
     }
+
+    #[test]
+    fn test_validator_production_resources() {
+        // Test recommended production resources for Validator
+        let validator_resources = hardcoded_defaults(&NodeType::Validator);
+
+        // Verify requests are reasonable for production
+        assert!(!validator_resources.requests.cpu.is_empty());
+        assert!(!validator_resources.requests.memory.is_empty());
+
+        // Verify limits are set
+        assert!(!validator_resources.limits.cpu.is_empty());
+        assert!(!validator_resources.limits.memory.is_empty());
+
+        // Validator should have at least 500m CPU and 1Gi memory
+        assert_eq!(validator_resources.requests.cpu, "500m");
+        assert_eq!(validator_resources.requests.memory, "1Gi");
+    }
+
+    #[test]
+    fn test_horizon_resources_lower_than_validator() {
+        // Horizon should have lower resource requirements than Validator
+        let validator = hardcoded_defaults(&NodeType::Validator);
+        let horizon = hardcoded_defaults(&NodeType::Horizon);
+
+        // Parse CPU requests (simplified comparison)
+        let validator_cpu = validator.requests.cpu.trim_end_matches('m');
+        let horizon_cpu = horizon.requests.cpu.trim_end_matches('m');
+
+        // Horizon should request less CPU than Validator
+        assert_eq!(horizon.requests.cpu, "250m");
+        assert_eq!(horizon.requests.memory, "512Mi");
+
+        // Verify Horizon has lower requests
+        let v_cpu: u32 = validator_cpu.parse().unwrap_or(500);
+        let h_cpu: u32 = horizon_cpu.parse().unwrap_or(250);
+        assert!(h_cpu < v_cpu, "Horizon CPU should be less than Validator");
+    }
+
+    #[test]
+    fn test_soroban_rpc_highest_resources() {
+        // Soroban RPC should have highest resource limits due to Wasm execution
+        let soroban = hardcoded_defaults(&NodeType::SorobanRpc);
+        let validator = hardcoded_defaults(&NodeType::Validator);
+        let horizon = hardcoded_defaults(&NodeType::Horizon);
+
+        // Soroban should have highest memory request
+        assert_eq!(soroban.requests.memory, "2Gi");
+        assert_eq!(soroban.limits.cpu, "4");
+        assert_eq!(soroban.limits.memory, "8Gi");
+
+        // Verify Soroban has higher limits than others
+        let soroban_limit_cpu: u32 = soroban.limits.cpu.parse().unwrap_or(4);
+        let validator_limit_cpu: u32 = validator.limits.cpu.parse().unwrap_or(2);
+        let horizon_limit_cpu: u32 = horizon.limits.cpu.parse().unwrap_or(2);
+
+        assert!(soroban_limit_cpu >= validator_limit_cpu);
+        assert!(soroban_limit_cpu >= horizon_limit_cpu);
+    }
+
+    #[test]
+    fn test_all_node_types_have_valid_resource_format() {
+        // Verify all node types have properly formatted resource strings
+        for node_type in [NodeType::Validator, NodeType::Horizon, NodeType::SorobanRpc] {
+            let resources = hardcoded_defaults(&node_type);
+
+            // CPU should end with 'm' (millicores) or be a number
+            assert!(
+                resources.requests.cpu.ends_with('m')
+                    || resources.requests.cpu.parse::<u32>().is_ok(),
+                "Invalid CPU format for {:?}: {}",
+                node_type,
+                resources.requests.cpu
+            );
+
+            // Memory should end with Gi, Mi, or be a number with unit
+            assert!(
+                resources.requests.memory.ends_with("Gi")
+                    || resources.requests.memory.ends_with("Mi")
+                    || resources.requests.memory.ends_with("Ki"),
+                "Invalid memory format for {:?}: {}",
+                node_type,
+                resources.requests.memory
+            );
+
+            // Limits should also be valid
+            assert!(
+                resources.limits.cpu.parse::<u32>().is_ok() || resources.limits.cpu.ends_with('m'),
+                "Invalid CPU limit format for {:?}: {}",
+                node_type,
+                resources.limits.cpu
+            );
+
+            assert!(
+                resources.limits.memory.ends_with("Gi")
+                    || resources.limits.memory.ends_with("Mi")
+                    || resources.limits.memory.ends_with("Ki"),
+                "Invalid memory limit format for {:?}: {}",
+                node_type,
+                resources.limits.memory
+            );
+        }
+    }
 }


### PR DESCRIPTION
This PR introduces comprehensive resource limits documentation and expands test coverage for default node resource configuration.

## Included Changes

### Documentation

Created `resource-limits.md` with guidance for the following node types:

- Validator
- Horizon
- Soroban RPC

The document includes:

- production and development resource recommendations
- resource precedence rules (`spec > Helm > hardcoded defaults`)
- storage guidance
- autoscaling recommendations
- monitoring and tuning advice
- performance and cost optimization notes
- troubleshooting for common resource-related failures
- hardcoded defaults reference table

### Tests

Added four new tests in `operator_config.rs`:

- `test_validator_production_resources()`
- `test_horizon_resources_lower_than_validator()`
- `test_soroban_rpc_highest_resources()`
- `test_all_node_types_have_valid_resource_format()`

These tests validate:

- minimum expected defaults
- relative resource sizing between node types
- Soroban RPC’s higher requirements
- correctness of CPU and memory resource string formats

## Validation

All checks pass successfully:

- `543` tests passing total
- `cargo check`
- `cargo clippy`
- `cargo fmt`
- doctests

## Motivation

This change improves the operator experience by documenting recommended deployment sizing and ensuring default resource definitions remain valid, consistent, and production-aware through automated tests.

## Scope

This PR includes:
- documentation
- tests
- validation of configuration defaults

It does not introduce new runtime logic or change reconciliation behavior.


closes #362

closes #363