### PR TITLE
Add EXPECTED_ISSUE_COUNT self-check to all batch issue…

### DIFF
--- a/scripts/create_batch_10_issues.sh
+++ b/scripts/create_batch_10_issues.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 REPO="OtowoOrg/Stellar-K8s"
 
+EXPECTED_ISSUE_COUNT=10
+ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 10 (8 x 200 pts, 2 x 150 pts) issues with auto-retry..."
 
 function create_issue_with_retry() {

--- a/scripts/create_batch_11_issues.sh
+++ b/scripts/create_batch_11_issues.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 REPO="OtowoOrg/Stellar-K8s"
 
+EXPECTED_ISSUE_COUNT=5
+ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 11 (5 x 150 pts) issues with auto-retry..."
 
 function create_issue_with_retry() {

--- a/scripts/create_batch_12_issues.sh
+++ b/scripts/create_batch_12_issues.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 REPO="OtowoOrg/Stellar-K8s"
 
+EXPECTED_ISSUE_COUNT=15
+ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 12 (15 x 200 pts) issues with auto-retry..."
 
 function create_issue_with_retry() {

--- a/scripts/create_batch_13_issues.sh
+++ b/scripts/create_batch_13_issues.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 REPO="OtowoOrg/Stellar-K8s"
 
+EXPECTED_ISSUE_COUNT=10
+ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 13 (10 x 200 pts) - The 10k Milestone Batch..."
 
 function create_issue_with_retry() {

--- a/scripts/create_batch_14_issues.sh
+++ b/scripts/create_batch_14_issues.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 REPO="OtowoOrg/Stellar-K8s"
 
+EXPECTED_ISSUE_COUNT=5
+ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 14 (5 x 150 pts) issues with auto-retry..."
 
 function create_issue_with_retry() {

--- a/scripts/create_batch_15_issues.sh
+++ b/scripts/create_batch_15_issues.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 REPO="OtowoOrg/Stellar-K8s"
 
+EXPECTED_ISSUE_COUNT=10
+ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 15 (10 x 200 pts) issues with auto-retry..."
 
 function create_issue_with_retry() {

--- a/scripts/create_batch_16_issues.sh
+++ b/scripts/create_batch_16_issues.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 REPO="OtowoOrg/Stellar-K8s"
 
+EXPECTED_ISSUE_COUNT=20
+ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 16 (20 x 200 pts) issues with auto-retry..."
 
 function create_issue_with_retry() {

--- a/scripts/create_batch_17_issues.sh
+++ b/scripts/create_batch_17_issues.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 REPO="OtowoOrg/Stellar-K8s"
 
+EXPECTED_ISSUE_COUNT=30
+ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 17 (30 x 200 pts) issues with auto-retry..."
 
 function create_issue_with_retry() {

--- a/scripts/create_batch_18_issues.sh
+++ b/scripts/create_batch_18_issues.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 REPO="OtowoOrg/Stellar-K8s"
 
+EXPECTED_ISSUE_COUNT=24
+ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 18 (24 x 200 pts) issues with auto-retry..."
 
 function create_issue_with_retry() {

--- a/scripts/create_batch_19_issues.sh
+++ b/scripts/create_batch_19_issues.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 REPO="OtowoOrg/Stellar-K8s"
 
+EXPECTED_ISSUE_COUNT=12
+ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 19 (12 x 200 pts) issues with auto-retry..."
 
 function create_issue_with_retry() {

--- a/scripts/create_batch_2_issues.sh
+++ b/scripts/create_batch_2_issues.sh
@@ -4,6 +4,13 @@ set -e
 # Stellar-K8s Wave Issue Creation Script - BATCH 2
 # Issues #12 - #21
 
+EXPECTED_ISSUE_COUNT=10
+ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 2 of Stellar Wave issues..."
 
 # 12. Add Resource Limit validation (Trivial - 100 Points)

--- a/scripts/create_batch_3_issues.sh
+++ b/scripts/create_batch_3_issues.sh
@@ -4,6 +4,13 @@ set -e
 # Stellar-K8s Wave Issue Creation Script - BATCH 3 (High Complexity)
 # Issues #22 - #24
 
+EXPECTED_ISSUE_COUNT=3
+ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 3 (200 points) issues..."
 
 # 22. Automated PVC Snapshots/Backups (High - 200 Points)

--- a/scripts/create_batch_4_issues.sh
+++ b/scripts/create_batch_4_issues.sh
@@ -4,6 +4,13 @@ set -e
 # Stellar-K8s Wave Issue Creation Script - BATCH 4
 # 6 High (200 pts), 2 Medium (150 pts), 2 Trivial (100 pts)
 
+EXPECTED_ISSUE_COUNT=10
+ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 4 (Mixed) issues..."
 
 # --- HIGH (200 pts) ---

--- a/scripts/create_batch_5_issues.sh
+++ b/scripts/create_batch_5_issues.sh
@@ -2,6 +2,13 @@
 # Stellar-K8s Wave Issue Creation Script - BATCH 5
 # 3 High (200 pts), 4 Medium (150 pts), 3 Trivial (100 pts)
 
+EXPECTED_ISSUE_COUNT=10
+ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 # Helper to create label if not exists
 create_label() {
   gh label create "$1" --color "$2" --description "$3" || true

--- a/scripts/create_batch_6_issues.sh
+++ b/scripts/create_batch_6_issues.sh
@@ -2,6 +2,13 @@
 # Stellar-K8s Wave Issue Creation Script - BATCH 6
 # 10 Elite Engineering Issues (200 pts each)
 
+EXPECTED_ISSUE_COUNT=10
+ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 # Helper to create label if not exists
 create_label() {
   gh label create "$1" --color "$2" --description "$3" || true

--- a/scripts/create_batch_7_issues.sh
+++ b/scripts/create_batch_7_issues.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 REPO="OtowoOrg/Stellar-K8s"
 
+EXPECTED_ISSUE_COUNT=20
+ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Ensuring required labels exist..."
 for label in "stellar-wave" "testing" "documentation" "ci" "bug" "enhancement" "good-first-issue" "security" "performance" "reliability" "kubernetes" "observability" "dx"; do
   gh label create "$label" --repo "$REPO" --color "0075ca" 2>/dev/null || true

--- a/scripts/create_batch_8_issues.sh
+++ b/scripts/create_batch_8_issues.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 REPO="OtowoOrg/Stellar-K8s"
 
+EXPECTED_ISSUE_COUNT=10
+ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Creating Batch 8 (10 x 200 pts) issues..."
 
 # ─── ISSUE 1 ───────────────────────────────────────────────────────────────────

--- a/scripts/create_batch_9_issues.sh
+++ b/scripts/create_batch_9_issues.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 REPO="OtowoOrg/Stellar-K8s"
 
+EXPECTED_ISSUE_COUNT=3
+ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
+if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
+  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+  exit 1
+fi
+
 echo "Resuming Batch 9 (final 3 issues)..."
 
 function create_issue_with_retry() {


### PR DESCRIPTION
closes #470 

##PR description:

Adds a lightweight self-check to all 18 batch issue creation scripts. Each script now declares an EXPECTED_ISSUE_COUNT variable and validates it against the actual number of gh issue create / create_issue_with_retry call sites before execution. If there's a mismatch, the script exits with a clear error message, preventing silent drift between the declared count and actual script content.