### PR TITLE
feat: add CLI version check and upgrade notification system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,7 +2379,6 @@ dependencies = [
  "serde_json",
 ]
 
-
 [[package]]
 name = "kube"
 version = "0.94.2"
@@ -2441,8 +2440,8 @@ dependencies = [
  "form_urlencoded",
  "http 1.4.0",
  "json-patch",
- "k8s-openapi 0.22.0",
- "schemars 0.8.22",
+ "k8s-openapi",
+ "schemars",
  "serde",
  "serde-value",
  "serde_json",
@@ -4446,7 +4445,7 @@ dependencies = [
  "hex",
  "hmac",
  "hostname",
- "k8s-openapi 0.22.0",
+ "k8s-openapi",
  "kube",
  "kube-runtime",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,6 @@ reconciler-fuzz = []
 
 # Kubernetes API version selection (exactly one must be enabled)
 k8s-v1-30 = ["k8s-openapi/v1_30"]
-k8s-v1-31 = ["k8s-openapi/v1_31"]
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub mod runbook;
 pub mod scheduler;
 pub mod search;
 pub mod telemetry;
+pub mod version_check;
 
 #[cfg(feature = "rest-api")]
 pub mod rest_api;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@ use std::process::{self};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use stellar_k8s::version_check;
+
 use chrono::Utc;
 use clap::{Parser, Subcommand};
 use k8s_openapi::api::coordination::v1::Lease;
@@ -51,6 +53,10 @@ stellar-operator version"
 struct Args {
     #[command(subcommand)]
     command: Commands,
+
+    /// Skip the background version check against GitHub releases.
+    #[arg(long, global = true, env = "STELLAR_OFFLINE")]
+    offline: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -382,20 +388,35 @@ struct BenchmarkArgs {
 async fn main() -> Result<(), Error> {
     let args = Args::parse();
 
-    match args.command {
+    // Run the version check in the background; it prints to stderr after the
+    // command completes so it never blocks or interrupts normal output.
+    let offline = args.offline;
+
+    // For short-lived commands, run the version check after the command completes.
+    // Long-running commands (run, webhook, benchmark) skip it to avoid noise.
+    let result = match args.command {
         Commands::Version => {
             println!("Stellar-K8s Operator v{}", env!("CARGO_PKG_VERSION"));
             println!("Build Date: {}", env!("BUILD_DATE"));
             println!("Git SHA: {}", env!("GIT_SHA"));
             println!("Rust Version: {}", env!("RUST_VERSION"));
-            return Ok(());
+            Ok(())
         }
-        Commands::Info(info_args) => {
-            return run_info(info_args).await;
+        Commands::Info(info_args) => run_info(info_args).await,
+        Commands::CheckCrd => run_check_crd().await,
+        Commands::PruneArchive(prune_args) => prune_archive(prune_args).await,
+        Commands::Diff(diff_args) => diff(diff_args).await,
+        Commands::GenerateRunbook(runbook_args) => run_generate_runbook(runbook_args).await,
+        Commands::IncidentReport(report_args) => incident::run_incident_report(report_args).await,
+        Commands::Completions { shell } => {
+            use clap::CommandFactory;
+            use clap_complete::generate;
+            let mut cmd = Args::command();
+            let name = cmd.get_name().to_string();
+            generate(shell, &mut cmd, name, &mut std::io::stdout());
+            Ok(())
         }
-        Commands::CheckCrd => {
-            return run_check_crd().await;
-        }
+        // Long-running commands: skip version check notification.
         Commands::Run(run_args) => {
             if let Err(e) = run_args.validate() {
                 eprintln!("error: {e}");
@@ -403,36 +424,15 @@ async fn main() -> Result<(), Error> {
             }
             return run_operator(run_args).await;
         }
-        Commands::Webhook(webhook_args) => {
-            return run_webhook(webhook_args).await;
-        }
+        Commands::Webhook(webhook_args) => return run_webhook(webhook_args).await,
         Commands::Benchmark(benchmark_args) => {
-            return run_benchmark_controller_cmd(benchmark_args).await;
+            return run_benchmark_controller_cmd(benchmark_args).await
         }
-        Commands::Simulator(cli) => {
-            return run_simulator(cli).await;
-        }
-        Commands::Completions { shell } => {
-            use clap::CommandFactory;
-            use clap_complete::generate;
-            let mut cmd = Args::command();
-            let name = cmd.get_name().to_string();
-            generate(shell, &mut cmd, name, &mut std::io::stdout());
-            return Ok(());
-        }
-        Commands::IncidentReport(args) => {
-            return incident::run_incident_report(args).await;
-        }
-        Commands::PruneArchive(args) => {
-            return prune_archive(args).await;
-        }
-        Commands::Diff(args) => {
-            return diff(args).await;
-        }
-        Commands::GenerateRunbook(args) => {
-            return run_generate_runbook(args).await;
-        }
-    }
+        Commands::Simulator(cli) => return run_simulator(cli).await,
+    };
+
+    version_check::check_and_notify(offline).await;
+    result
 }
 
 async fn run_simulator(cli: SimulatorCli) -> Result<(), Error> {
@@ -1745,5 +1745,26 @@ mod cli_tests {
     fn simulator_up_custom_cluster() {
         let args = parse_simulator_up(&["--cluster-name", "my-cluster"]).unwrap();
         assert_eq!(args.cluster_name, "my-cluster");
+    }
+
+    // ── offline flag ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn offline_flag_is_false_by_default() {
+        let parsed = Args::try_parse_from(["stellar-operator", "version"]).unwrap();
+        assert!(!parsed.offline);
+    }
+
+    #[test]
+    fn offline_flag_can_be_set() {
+        let parsed = Args::try_parse_from(["stellar-operator", "--offline", "version"]).unwrap();
+        assert!(parsed.offline);
+    }
+
+    #[test]
+    fn offline_flag_is_global_on_subcommand() {
+        // --offline placed after the subcommand should also work (global flag)
+        let parsed = Args::try_parse_from(["stellar-operator", "check-crd", "--offline"]).unwrap();
+        assert!(parsed.offline);
     }
 }

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -1,0 +1,158 @@
+//! CLI version check: fetches the latest GitHub release and notifies the user
+//! if a newer version is available. Results are cached for 24 hours.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+const GITHUB_API_URL: &str = "https://api.github.com/repos/stellar/stellar-k8s/releases/latest";
+const CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[derive(Serialize, Deserialize)]
+struct Cache {
+    /// Unix timestamp when the cache was written.
+    fetched_at: u64,
+    /// Latest version tag (e.g. "v0.2.0").
+    latest_version: String,
+}
+
+fn cache_path() -> PathBuf {
+    std::env::temp_dir().join("stellar-k8s-version-cache.json")
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn read_cache() -> Option<String> {
+    let data = fs::read_to_string(cache_path()).ok()?;
+    let cache: Cache = serde_json::from_str(&data).ok()?;
+    if now_secs().saturating_sub(cache.fetched_at) < CACHE_TTL.as_secs() {
+        Some(cache.latest_version)
+    } else {
+        None
+    }
+}
+
+fn write_cache(version: &str) {
+    let cache = Cache {
+        fetched_at: now_secs(),
+        latest_version: version.to_string(),
+    };
+    if let Ok(json) = serde_json::to_string(&cache) {
+        let _ = fs::write(cache_path(), json);
+    }
+}
+
+/// Fetch the latest release tag from GitHub (blocking via a one-shot tokio task).
+async fn fetch_latest_version() -> Option<String> {
+    #[derive(Deserialize)]
+    struct Release {
+        tag_name: String,
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .user_agent(concat!("stellar-k8s/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .ok()?;
+
+    let release: Release = client
+        .get(GITHUB_API_URL)
+        .send()
+        .await
+        .ok()?
+        .json()
+        .await
+        .ok()?;
+
+    Some(release.tag_name)
+}
+
+/// Strip a leading `v` from a version string for comparison.
+fn strip_v(s: &str) -> &str {
+    s.strip_prefix('v').unwrap_or(s)
+}
+
+/// Check for a newer version and print a notification to stderr if one exists.
+///
+/// Pass `offline = true` to skip the network request entirely.
+pub async fn check_and_notify(offline: bool) {
+    if offline {
+        return;
+    }
+
+    let latest = if let Some(cached) = read_cache() {
+        cached
+    } else {
+        match fetch_latest_version().await {
+            Some(v) => {
+                write_cache(&v);
+                v
+            }
+            None => return, // network unavailable — fail silently
+        }
+    };
+
+    let current = env!("CARGO_PKG_VERSION");
+    if strip_v(&latest) != strip_v(current) {
+        eprintln!(
+            "\n\x1b[33m[stellar-k8s] A new version is available: {} (you have v{})\x1b[0m",
+            latest, current
+        );
+        eprintln!("\x1b[33m  → https://github.com/stellar/stellar-k8s/releases/latest\x1b[0m\n");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_v_removes_prefix() {
+        assert_eq!(strip_v("v0.2.0"), "0.2.0");
+        assert_eq!(strip_v("0.2.0"), "0.2.0");
+    }
+
+    #[test]
+    fn strip_v_same_version_no_notification() {
+        let current = env!("CARGO_PKG_VERSION");
+        let latest = format!("v{current}");
+        assert_eq!(strip_v(&latest), strip_v(current));
+    }
+
+    #[test]
+    fn cache_roundtrip() {
+        // Write a cache entry and read it back.
+        let tmp = std::env::temp_dir().join("stellar-k8s-version-cache-test.json");
+        let cache = Cache {
+            fetched_at: now_secs(),
+            latest_version: "v9.9.9".to_string(),
+        };
+        let json = serde_json::to_string(&cache).unwrap();
+        fs::write(&tmp, &json).unwrap();
+
+        let data = fs::read_to_string(&tmp).unwrap();
+        let parsed: Cache = serde_json::from_str(&data).unwrap();
+        assert_eq!(parsed.latest_version, "v9.9.9");
+        let _ = fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn expired_cache_returns_none() {
+        let cache = Cache {
+            // 25 hours ago
+            fetched_at: now_secs().saturating_sub(25 * 60 * 60),
+            latest_version: "v0.0.1".to_string(),
+        };
+        let json = serde_json::to_string(&cache).unwrap();
+        fs::write(cache_path(), &json).unwrap();
+        // read_cache should return None because TTL has elapsed
+        assert!(read_cache().is_none());
+    }
+}


### PR DESCRIPTION
CLOSE #515 

src/version_check.rs (new file):
- check_and_notify(offline: bool) — the public entry point. Skips immediately if offline = true
- Reads a 24h cache from /tmp/stellar-k8s-version-cache.json before hitting the network
- Fetches https://api.github.com/repos/stellar/stellar-k8s/releases/latest with a 5s timeout and proper User-Agent
- Writes the result to cache on success; silently returns on any network failure
- Compares tag_name (stripping leading v) against CARGO_PKG_VERSION and prints a yellow notice to stderr if different

src/main.rs:
- Added --offline global flag (also reads STELLAR_OFFLINE env var) to Args
- Restructured main() so short-lived commands (version, check-crd, info, diff, prune-archive, generate-runbook, incident-report, completions) run the version check after they complete
- Long-running daemon commands (run, webhook, benchmark, simulator) skip it — no noise in operator logs
- Added 3 tests for the --offline flag parsing

Cargo.toml: Removed the invalid k8s-v1-31 = ["k8s-openapi/v1_31"] feature — k8s-openapi 0.22 doesn't have that feature, which was causing cargo to fail on every build command on main.
