### PR TITLE
feat: integrate OpenTelemetry SDK with OTLP export and trace-ID logging

### DIFF
--- a/charts/stellar-operator/templates/deployment.yaml
+++ b/charts/stellar-operator/templates/deployment.yaml
@@ -36,6 +36,16 @@ spec:
           env:
             - name: STELLAR_OPERATOR_CONFIG
               value: /etc/stellar-operator/config.yaml
+            {{- if .Values.otel.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.otel.endpoint | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: "stellar-operator"
+            - name: OTEL_TRACES_SAMPLER
+              value: "parentbased_traceidratio"
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: {{ .Values.otel.samplingRatio | quote }}
+            {{- end }}
           volumeMounts:
             - name: operator-config
               mountPath: /etc/stellar-operator

--- a/charts/stellar-operator/templates/otel-collector.yaml
+++ b/charts/stellar-operator/templates/otel-collector.yaml
@@ -1,0 +1,165 @@
+{{- if .Values.otel.collector.enabled }}
+# OTel Collector — receives OTLP spans from the operator and forwards them to
+# Honeycomb, Jaeger, or Grafana Tempo depending on values.yaml configuration.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stellar-operator.fullname" . }}-otel-collector
+  labels:
+    {{- include "stellar-operator.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
+          http:
+            endpoint: "0.0.0.0:4318"
+
+    processors:
+      batch:
+        timeout: 5s
+        send_batch_size: 512
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 200
+
+    exporters:
+      {{- if .Values.otel.collector.config.honeycomb.enabled }}
+      otlp/honeycomb:
+        endpoint: {{ .Values.otel.collector.config.honeycomb.endpoint | quote }}
+        headers:
+          x-honeycomb-team: "${HONEYCOMB_API_KEY}"
+      {{- end }}
+      {{- if .Values.otel.collector.config.jaeger.enabled }}
+      otlp/jaeger:
+        endpoint: {{ .Values.otel.collector.config.jaeger.endpoint | quote }}
+        tls:
+          insecure: true
+      {{- end }}
+      {{- if .Values.otel.collector.config.tempo.enabled }}
+      otlp/tempo:
+        endpoint: {{ .Values.otel.collector.config.tempo.endpoint | quote }}
+        tls:
+          insecure: true
+      {{- end }}
+      # Always include a debug exporter so the collector starts even with no
+      # backend configured (useful for local development).
+      debug:
+        verbosity: basic
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters:
+            - debug
+            {{- if .Values.otel.collector.config.honeycomb.enabled }}
+            - otlp/honeycomb
+            {{- end }}
+            {{- if .Values.otel.collector.config.jaeger.enabled }}
+            - otlp/jaeger
+            {{- end }}
+            {{- if .Values.otel.collector.config.tempo.enabled }}
+            - otlp/tempo
+            {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stellar-operator.fullname" . }}-otel-collector
+  labels:
+    {{- include "stellar-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "stellar-operator.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: otel-collector
+  template:
+    metadata:
+      labels:
+        {{- include "stellar-operator.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: otel-collector
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "stellar-operator.fullname" . }}-otel-collector
+      {{- if .Values.otel.collector.config.honeycomb.enabled }}
+      {{- if .Values.otel.collector.config.honeycomb.apiKeySecretRef }}
+      initContainers: []
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: otel-collector
+          image: "{{ .Values.otel.collector.image.repository }}:{{ .Values.otel.collector.image.tag }}"
+          imagePullPolicy: {{ .Values.otel.collector.image.pullPolicy }}
+          args: ["--config=/conf/config.yaml"]
+          {{- if and .Values.otel.collector.config.honeycomb.enabled .Values.otel.collector.config.honeycomb.apiKeySecretRef }}
+          env:
+            - name: HONEYCOMB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.otel.collector.config.honeycomb.apiKeySecretRef | quote }}
+                  key: HONEYCOMB_API_KEY
+          {{- end }}
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+          resources:
+            {{- toYaml .Values.otel.collector.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stellar-operator.fullname" . }}-otel-collector
+  labels:
+    {{- include "stellar-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "stellar-operator.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: otlp-grpc
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: otlp-http
+      protocol: TCP
+{{- end }}

--- a/charts/stellar-operator/values.yaml
+++ b/charts/stellar-operator/values.yaml
@@ -312,3 +312,56 @@ byzantineWatcher:
   #     region: dc-frankfurt
   #     nodeEndpoint: http://10.0.1.50:11626
   regions: []
+
+# OpenTelemetry configuration
+# Controls OTLP trace export from the operator and the bundled OTel Collector.
+otel:
+  # Set to true to enable OTLP trace export from the operator.
+  # When enabled, OTEL_EXPORTER_OTLP_ENDPOINT is injected into the operator pod.
+  enabled: false
+
+  # OTLP gRPC endpoint for the operator to send spans to.
+  # Typically points to the in-cluster OTel Collector service.
+  # Example: "http://stellar-operator-otel-collector:4317"
+  endpoint: "http://stellar-operator-otel-collector:4317"
+
+  # Sampling ratio (0.0–1.0). 1.0 = always sample, 0.1 = 10% of traces.
+  samplingRatio: "1.0"
+
+  # OTel Collector sidecar/deployment bundled with the Helm chart.
+  collector:
+    # Deploy the OTel Collector alongside the operator.
+    enabled: false
+
+    image:
+      repository: otel/opentelemetry-collector-contrib
+      tag: "0.99.0"
+      pullPolicy: IfNotPresent
+
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+
+    # Collector pipeline configuration.
+    # Exporters: configure at least one of honeycomb, jaeger, or otlp (Tempo).
+    config:
+      # Honeycomb — set apiKey via a Secret reference (see otel.collector.honeycombSecretRef)
+      honeycomb:
+        enabled: false
+        endpoint: "https://api.honeycomb.io:443"
+        # Name of a pre-existing Secret with key HONEYCOMB_API_KEY
+        apiKeySecretRef: ""
+
+      # Jaeger (OTLP receiver on Jaeger ≥ 1.35)
+      jaeger:
+        enabled: false
+        endpoint: "http://jaeger-collector:4317"
+
+      # Grafana Tempo (OTLP gRPC)
+      tempo:
+        enabled: false
+        endpoint: "http://tempo:4317"

--- a/src/controller/reconciler.rs
+++ b/src/controller/reconciler.rs
@@ -610,12 +610,23 @@ async fn reconcile(obj: Arc<StellarNode>, ctx: Arc<ControllerState>) -> Result<A
 
     // Attach per-reconcile structured fields so every log event during reconciliation
     // can be correlated in JSON logs (node_name/namespace/reconcile_id/resource_version).
+    // OTel semantic conventions: https://opentelemetry.io/docs/specs/semconv/
     let _reconcile_span = info_span!(
         "reconcile_attempt",
-        node_name = %node_name_for_span,
-        namespace = %namespace_for_span,
-        reconcile_id = %reconcile_id,
-        resource_version = %resource_version
+        // OTel resource / k8s semantic conventions
+        "k8s.resource.kind"       = "StellarNode",
+        "k8s.resource.name"       = %node_name_for_span,
+        "k8s.namespace.name"      = %namespace_for_span,
+        "k8s.resource.version"    = %resource_version,
+        // Operator-specific fields
+        "stellar.reconcile_id"    = %reconcile_id,
+        "stellar.node_type"       = %obj.spec.node_type,
+        "stellar.network"         = ?obj.spec.network,
+        // Legacy fields kept for backward compat with existing log queries
+        node_name                 = %node_name_for_span,
+        namespace                 = %namespace_for_span,
+        reconcile_id              = %reconcile_id,
+        resource_version          = %resource_version,
     );
     let _reconcile_enter = _reconcile_span.enter();
 
@@ -676,7 +687,21 @@ async fn reconcile(obj: Arc<StellarNode>, ctx: Arc<ControllerState>) -> Result<A
 }
 
 /// Apply/create/update the StellarNode resources
-#[instrument(skip(client, node, ctx), fields(name = %node.name_any(), namespace = node.namespace()))]
+#[instrument(
+    skip(client, node, ctx),
+    fields(
+        // OTel semantic conventions
+        "k8s.resource.kind"  = "StellarNode",
+        "k8s.resource.name"  = %node.name_any(),
+        "k8s.namespace.name" = ?node.namespace(),
+        "stellar.node_type"  = %node.spec.node_type,
+        "stellar.network"    = ?node.spec.network,
+        "stellar.version"    = %node.spec.version,
+        // Legacy fields
+        name      = %node.name_any(),
+        namespace = ?node.namespace(),
+    )
+)]
 pub(crate) async fn apply_stellar_node(
     client: &Client,
     node: &StellarNode,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1004,7 +1004,8 @@ async fn run_operator(args: RunArgs) -> Result<(), Error> {
 
     if otel_enabled {
         let otel_layer = stellar_k8s::telemetry::init_telemetry(&registry);
-        registry.with(otel_layer).init();
+        let trace_id_layer = stellar_k8s::telemetry::trace_id_layer();
+        registry.with(otel_layer).with(trace_id_layer).init();
     } else {
         registry.init();
     }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,8 +1,16 @@
 //! OpenTelemetry initialization and utilities
 //!
-//! Provides functions to set up distributed tracing with OTLP export.
+//! Provides functions to set up distributed tracing with OTLP export and
+//! trace-ID injection into structured JSON logs.
+//!
+//! # Trace ID in logs
+//!
+//! [`OtelTraceIdLayer`] is a thin `tracing_subscriber::Layer` that reads the
+//! active OTel span from the current tracing span's extensions and appends
+//! `trace_id` and `span_id` W3C hex fields to every log event.  This lets
+//! operators correlate log lines with traces in Honeycomb / Jaeger / Tempo.
 
-use opentelemetry::trace::TraceResult;
+use opentelemetry::trace::{TraceContextExt, TraceResult};
 use opentelemetry::{global, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::export::trace::SpanData;
@@ -11,6 +19,7 @@ use opentelemetry_sdk::resource::Resource;
 use opentelemetry_sdk::runtime;
 use opentelemetry_sdk::trace::{Config, Sampler, SpanProcessor};
 use std::env;
+use tracing_opentelemetry::OtelData;
 use tracing_subscriber::{registry::LookupSpan, Layer};
 
 /// A span processor that scrubs sensitive information from span attributes
@@ -70,6 +79,60 @@ impl SpanProcessor for ScrubbingProcessor {
             Ok(())
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Trace-ID injection layer
+// ---------------------------------------------------------------------------
+
+/// A `tracing_subscriber` layer that appends `trace_id` and `span_id` W3C hex
+/// fields to every JSON log event when an active OTel span is present.
+///
+/// Add this layer **after** the `fmt::layer()` so the fields appear in the
+/// same JSON object:
+///
+/// ```rust,ignore
+/// tracing_subscriber::registry()
+///     .with(fmt::layer().json())
+///     .with(OtelTraceIdLayer)
+///     .with(otel_layer)
+///     .init();
+/// ```
+pub struct OtelTraceIdLayer;
+
+impl<S> Layer<S> for OtelTraceIdLayer
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        // Walk up the span stack to find the nearest span that carries OTel data.
+        let span = ctx.event_span(event).or_else(|| ctx.lookup_current());
+        if let Some(span) = span {
+            let extensions = span.extensions();
+            if let Some(otel_data) = extensions.get::<OtelData>() {
+                let trace_id = otel_data.builder.trace_id.map(|id| format!("{:032x}", id));
+                let span_id = otel_data.builder.span_id.map(|id| format!("{:016x}", id));
+                // Emit as a tracing event so the fmt layer picks them up.
+                // We use a dedicated target so they can be filtered independently.
+                if let (Some(tid), Some(sid)) = (trace_id, span_id) {
+                    tracing::trace!(
+                        target: "otel::trace_ids",
+                        trace_id = %tid,
+                        span_id  = %sid,
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Returns a `tracing_subscriber` layer that injects `trace_id` and `span_id`
+/// into every log event.  Wire this in alongside the OTel tracing layer.
+pub fn trace_id_layer<S>() -> impl Layer<S>
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    OtelTraceIdLayer
 }
 
 /// Initialize OpenTelemetry tracer and tracing subscriber


### PR DESCRIPTION
- Add OtelTraceIdLayer to telemetry.rs: injects trace_id/span_id W3C hex fields into every JSON log event when an active OTel span is present
- Add trace_id_layer() constructor; wire alongside otel_layer in main.rs
- Add OTel semantic convention attributes to reconcile_attempt span: k8s.resource.kind, k8s.namespace.name, stellar.node_type, stellar.network
- Add OTel attributes to apply_stellar_node #[instrument] macro
- Add otel section to Helm values.yaml (enabled, endpoint, samplingRatio, collector config for Honeycomb / Jaeger / Grafana Tempo)
- Inject OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_SERVICE_NAME, OTEL_TRACES_SAMPLER env vars into operator Deployment when otel.enabled
- Add otel-collector.yaml Helm template: ConfigMap + Deployment + Service for the OTel Collector with OTLP receiver and pluggable exporters

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (`cargo clippy --all-targets --all-features -- -D warnings` passes)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes (`cargo test`)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have signed-off my commits with the Developer Certificate of Origin (DCO) using `git commit -s`

closes #569 