### PR TITLE
feat: implement Stellar Fork Detection sidecar

### DIFF
--- a/.github/workflows/multiarch-build.yml
+++ b/.github/workflows/multiarch-build.yml
@@ -1,0 +1,211 @@
+name: Multi-Arch Build & Verify
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Build multi-arch manifest and verify both platforms boot correctly.
+  # ─────────────────────────────────────────────────────────────────────────────
+  build-multiarch:
+    name: Build (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image for ${{ matrix.platform }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: false
+          load: true
+          tags: stellar-k8s-test:${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          build-args: |
+            BUILDPLATFORM=linux/amd64
+            TARGETPLATFORM=${{ matrix.platform }}
+
+      - name: Verify binary architecture
+        run: |
+          ARCH=${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          docker run --rm --platform ${{ matrix.platform }} \
+            stellar-k8s-test:${ARCH} \
+            /stellar-operator version
+          echo "✓ stellar-operator boots on ${{ matrix.platform }}"
+
+          docker run --rm --platform ${{ matrix.platform }} \
+            stellar-k8s-test:${ARCH} \
+            /stellar-fork-detector --help
+          echo "✓ stellar-fork-detector boots on ${{ matrix.platform }}"
+
+          docker run --rm --platform ${{ matrix.platform }} \
+            stellar-k8s-test:${ARCH} \
+            /stellar-watcher --help
+          echo "✓ stellar-watcher boots on ${{ matrix.platform }}"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Publish combined multi-arch manifest (main branch only).
+  # ─────────────────────────────────────────────────────────────────────────────
+  publish-manifest:
+    name: Publish Multi-Arch Manifest
+    runs-on: ubuntu-latest
+    needs: build-multiarch
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=edge
+
+      - name: Build and push multi-arch manifest
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:edge
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Architecture performance benchmark comparison.
+  # Runs a quick reconciliation throughput test on both arches.
+  # ─────────────────────────────────────────────────────────────────────────────
+  arch-benchmark:
+    name: Arch Benchmark (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    needs: build-multiarch
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm  # GitHub-hosted ARM64 runner
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.arch }}-bench-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run reconciler benchmark
+        run: |
+          cargo test --release --lib -- --nocapture 2>&1 | tee bench-${{ matrix.arch }}.txt
+          echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-${{ matrix.arch }}
+          path: bench-${{ matrix.arch }}.txt
+
+  compare-arch-benchmarks:
+    name: Compare ARM vs AMD Benchmarks
+    runs-on: ubuntu-latest
+    needs: arch-benchmark
+    if: always()
+    steps:
+      - name: Download amd64 results
+        uses: actions/download-artifact@v4
+        with:
+          name: bench-amd64
+          path: results/
+
+      - name: Download arm64 results
+        uses: actions/download-artifact@v4
+        with:
+          name: bench-arm64
+          path: results/
+
+      - name: Print comparison
+        run: |
+          echo "## Architecture Benchmark Comparison" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### AMD64 (x86_64)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat results/bench-amd64.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### ARM64 (Graviton / Apple Silicon)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat results/bench-arm64.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,10 +777,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -3179,7 +3179,7 @@ dependencies = [
  "serde_yaml",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.23.1",
  "tokio-util",
  "tower 0.4.13",
  "tower-http 0.5.2",
@@ -5779,7 +5779,19 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.23.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -6065,6 +6077,22 @@ dependencies = [
  "sha1 0.10.6",
  "thiserror 1.0.69",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,4 +190,11 @@ name = "stellar-watcher"
 path = "src/bin/stellar-watcher.rs"
 required-features = ["rest-api", "metrics"]
 
+# Fork Detection Sidecar — compares local ledger hash against public anchors
+# to detect potential network forks early.
+[[bin]]
+name = "stellar-fork-detector"
+path = "src/bin/stellar-fork-detector.rs"
+required-features = ["rest-api", "metrics"]
+
 [workspace]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # syntax=docker/dockerfile:1.7
 # ==============================================================================
 # Stage 1: Chef - Dependency Caching Layer
+# Multi-arch: supports linux/amd64 and linux/arm64 (Graviton, Apple Silicon)
 # ==============================================================================
-FROM lukemathwalker/cargo-chef:latest-rust-1.93 AS chef
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:latest-rust-1.93 AS chef
 WORKDIR /app
 
 # ==============================================================================
@@ -14,15 +15,36 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 # ==============================================================================
 # Stage 3: Builder - Build dependencies (cached) then application
+# TARGETPLATFORM / TARGETARCH are injected by docker buildx automatically.
 # ==============================================================================
 FROM chef AS builder
+
+ARG TARGETPLATFORM
+ARG TARGETARCH
+ARG BUILDPLATFORM
+
+# Install cross-compilation toolchains when building for arm64 on amd64 host.
+RUN if [ "$TARGETARCH" = "arm64" ] && [ "$BUILDPLATFORM" != "$TARGETPLATFORM" ]; then \
+      apt-get update -qq && \
+      apt-get install -y --no-install-recommends \
+        gcc-aarch64-linux-gnu \
+        libc6-dev-arm64-cross && \
+      rustup target add aarch64-unknown-linux-gnu; \
+    fi
+
+# Set Cargo target based on TARGETARCH.
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 
 # Copy the recipe and build dependencies first (cached layer)
 COPY --from=planner /app/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/usr/local/cargo/git \
   --mount=type=cache,target=/app/target \
-  cargo chef cook --release --recipe-path recipe.json
+  if [ "$TARGETARCH" = "arm64" ] && [ "$BUILDPLATFORM" != "$TARGETPLATFORM" ]; then \
+    cargo chef cook --release --target aarch64-unknown-linux-gnu --recipe-path recipe.json; \
+  else \
+    cargo chef cook --release --recipe-path recipe.json; \
+  fi
 
 # Now copy source and build binaries in a single step to share
 # the dependency cache layer and avoid redundant recompilation.
@@ -30,17 +52,33 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/usr/local/cargo/git \
   --mount=type=cache,target=/app/target \
-  cargo build --release \
-    --bin stellar-operator \
-    --bin kubectl-stellar \
-    --bin stellar-sidecar \
-    --bin stellar-watcher
+  if [ "$TARGETARCH" = "arm64" ] && [ "$BUILDPLATFORM" != "$TARGETPLATFORM" ]; then \
+    cargo build --release --target aarch64-unknown-linux-gnu \
+      --bin stellar-operator \
+      --bin kubectl-stellar \
+      --bin stellar-sidecar \
+      --bin stellar-watcher \
+      --bin stellar-fork-detector && \
+    cp target/aarch64-unknown-linux-gnu/release/stellar-operator target/release/ && \
+    cp target/aarch64-unknown-linux-gnu/release/kubectl-stellar target/release/ && \
+    cp target/aarch64-unknown-linux-gnu/release/stellar-sidecar target/release/ && \
+    cp target/aarch64-unknown-linux-gnu/release/stellar-watcher target/release/ && \
+    cp target/aarch64-unknown-linux-gnu/release/stellar-fork-detector target/release/; \
+  else \
+    cargo build --release \
+      --bin stellar-operator \
+      --bin kubectl-stellar \
+      --bin stellar-sidecar \
+      --bin stellar-watcher \
+      --bin stellar-fork-detector; \
+  fi
 
 # Strip binaries to reduce image size
 RUN strip /app/target/release/stellar-operator \
     && strip /app/target/release/kubectl-stellar \
     && strip /app/target/release/stellar-sidecar \
-    && strip /app/target/release/stellar-watcher
+    && strip /app/target/release/stellar-watcher \
+    && strip /app/target/release/stellar-fork-detector
 
 # ==============================================================================
 # Stage 4: Local Binaries - Fast local packaging from host build artifacts
@@ -90,6 +128,7 @@ COPY --from=builder /app/target/release/stellar-operator /stellar-operator
 COPY --from=builder /app/target/release/kubectl-stellar /kubectl-stellar
 COPY --from=builder /app/target/release/stellar-sidecar /stellar-sidecar
 COPY --from=builder /app/target/release/stellar-watcher /stellar-watcher
+COPY --from=builder /app/target/release/stellar-fork-detector /stellar-fork-detector
 
 # Run as non-root user (UID 65532 is the nonroot user in distroless)
 USER nonroot:nonroot

--- a/charts/stellar-operator/templates/deployment.yaml
+++ b/charts/stellar-operator/templates/deployment.yaml
@@ -115,9 +115,60 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
         {{- end }}
+        {{- if .Values.forkDetector.enabled }}
+        - name: fork-detector
+          image: "{{ .Values.forkDetector.image.repository | default .Values.image.repository }}:{{ .Values.forkDetector.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.forkDetector.image.pullPolicy | default .Values.image.pullPolicy }}
+          command: ["/stellar-fork-detector"]
+          env:
+            - name: FORK_DETECTOR_LOCAL_ENDPOINT
+              value: {{ .Values.forkDetector.localEndpoint | quote }}
+            - name: FORK_DETECTOR_ANCHORS
+              value: {{ join "," .Values.forkDetector.anchors | quote }}
+            - name: FORK_DETECTOR_POLL_INTERVAL
+              value: {{ .Values.forkDetector.pollIntervalSecs | quote }}
+            - name: FORK_DETECTOR_DIVERGENCE_THRESHOLD
+              value: {{ .Values.forkDetector.divergenceThreshold | quote }}
+            - name: FORK_DETECTOR_METRICS_BIND
+              value: "0.0.0.0:{{ .Values.forkDetector.metricsPort }}"
+            - name: FORK_DETECTOR_NETWORK
+              value: {{ .Values.operator.watchNamespace | default "mainnet" | quote }}
+            - name: FORK_DETECTOR_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: RUST_LOG
+              value: {{ .Values.operator.logLevel }}
+          ports:
+            - name: fork-metrics
+              containerPort: {{ .Values.forkDetector.metricsPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: fork-metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: fork-metrics
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.forkDetector.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.arch }}
+      {{- if not .Values.nodeSelector }}
+      nodeSelector:
+      {{- end }}
+        kubernetes.io/arch: {{ .Values.arch }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
@@ -126,4 +177,13 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.arch }}
+      {{- if not .Values.tolerations }}
+      tolerations:
+      {{- end }}
+        - key: "kubernetes.io/arch"
+          operator: "Equal"
+          value: {{ .Values.arch }}
+          effect: "NoSchedule"
       {{- end }}

--- a/charts/stellar-operator/templates/fork-detector.yaml
+++ b/charts/stellar-operator/templates/fork-detector.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.forkDetector.enabled }}
+---
+# Fork Detection Sidecar — standalone Deployment (for operator pod).
+# When deploying alongside individual StellarNode pods, the sidecar is injected
+# via the deployment.yaml template instead.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stellar-operator.fullname" . }}-fork-detector
+  labels:
+    {{- include "stellar-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fork-detector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "stellar-operator.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: fork-detector
+  template:
+    metadata:
+      labels:
+        {{- include "stellar-operator.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: fork-detector
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.forkDetector.metricsPort | quote }}
+        prometheus.io/path: "/metrics"
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "stellar-operator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: fork-detector
+          image: "{{ .Values.forkDetector.image.repository | default .Values.image.repository }}:{{ .Values.forkDetector.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.forkDetector.image.pullPolicy | default .Values.image.pullPolicy }}
+          command: ["/stellar-fork-detector"]
+          env:
+            - name: FORK_DETECTOR_LOCAL_ENDPOINT
+              value: {{ .Values.forkDetector.localEndpoint | quote }}
+            - name: FORK_DETECTOR_ANCHORS
+              value: {{ join "," .Values.forkDetector.anchors | quote }}
+            - name: FORK_DETECTOR_POLL_INTERVAL
+              value: {{ .Values.forkDetector.pollIntervalSecs | quote }}
+            - name: FORK_DETECTOR_DIVERGENCE_THRESHOLD
+              value: {{ .Values.forkDetector.divergenceThreshold | quote }}
+            - name: FORK_DETECTOR_METRICS_BIND
+              value: "0.0.0.0:{{ .Values.forkDetector.metricsPort }}"
+            - name: FORK_DETECTOR_NETWORK
+              value: {{ .Values.byzantineWatcher.defaultNetwork | default "mainnet" | quote }}
+            - name: FORK_DETECTOR_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: RUST_LOG
+              value: {{ .Values.operator.logLevel }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.forkDetector.metricsPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: metrics
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.forkDetector.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.arch }}
+        kubernetes.io/arch: {{ .Values.arch }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stellar-operator.fullname" . }}-fork-detector
+  labels:
+    {{- include "stellar-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fork-detector
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: {{ .Values.forkDetector.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    {{- include "stellar-operator.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: fork-detector
+{{- end }}

--- a/charts/stellar-operator/values.yaml
+++ b/charts/stellar-operator/values.yaml
@@ -88,6 +88,22 @@ tolerations: []
 
 affinity: {}
 
+# Multi-architecture support
+# Allows targeting specific CPU architectures (amd64 / arm64 / Graviton).
+# Set arch to "arm64" to schedule on ARM/Graviton nodes, "amd64" for x86.
+# Leave empty to allow scheduling on any architecture.
+arch: ""
+
+# Example — pin operator to ARM64 (Graviton) nodes:
+# arch: arm64
+# nodeSelector:
+#   kubernetes.io/arch: arm64
+# tolerations:
+#   - key: "kubernetes.io/arch"
+#     operator: "Equal"
+#     value: "arm64"
+#     effect: "NoSchedule"
+
 # PodDisruptionBudget configuration for operator deployment
 podDisruptionBudget:
   enabled: false
@@ -118,6 +134,35 @@ sidecar:
       memory: 64Mi
     requests:
       cpu: 50m
+      memory: 32Mi
+
+# Fork Detection Sidecar — compares local ledger hash against public anchors.
+# Deploy alongside each StellarNode validator pod to detect network forks early.
+forkDetector:
+  enabled: false
+  image:
+    repository: ghcr.io/stellar/stellar-k8s
+    tag: ""
+    pullPolicy: IfNotPresent
+  # Local Stellar Core endpoint (within the same pod).
+  localEndpoint: "http://localhost:11626"
+  # Public Horizon anchor endpoints (minimum 3 recommended).
+  anchors:
+    - "https://horizon.stellar.org/ledgers?order=desc&limit=1"
+    - "https://horizon.stellar.lobstr.co/ledgers?order=desc&limit=1"
+    - "https://horizon.satoshipay.io/ledgers?order=desc&limit=1"
+  # Poll interval in seconds.
+  pollIntervalSecs: 5
+  # Number of consecutive diverging ledgers before alerting.
+  divergenceThreshold: 3
+  # Prometheus metrics port.
+  metricsPort: 9102
+  resources:
+    limits:
+      cpu: 100m
+      memory: 64Mi
+    requests:
+      cpu: 25m
       memory: 32Mi
 
 # Service for REST API and metrics

--- a/monitoring/fork-detector-alerts.yaml
+++ b/monitoring/fork-detector-alerts.yaml
@@ -1,0 +1,118 @@
+---
+# Fork Detection Sidecar — PrometheusRule
+#
+# Fires alerts when the local Stellar Core node's ledger hash diverges from
+# the public anchor majority, indicating a potential network fork.
+#
+# Deploy to the same namespace as your Prometheus instance:
+#   kubectl apply -f monitoring/fork-detector-alerts.yaml -n monitoring
+#
+# Prerequisites:
+#   - Prometheus Operator (kube-prometheus-stack or standalone)
+#   - stellar-fork-detector sidecar deployed and scraped by Prometheus
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: stellar-fork-detector
+  namespace: monitoring
+  labels:
+    app: stellar-operator
+    component: fork-detector
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: stellar.fork_detector.alerts
+      rules:
+        # ── CRITICAL: Fork confirmed ──────────────────────────────────────────
+        # Fires when divergence has persisted for 3+ consecutive ledgers.
+        - alert: StellarForkDetected
+          expr: |
+            stellar_fork_detector_consecutive_diverging_ledgers >= 3
+          for: 0m
+          labels:
+            severity: critical
+            team: stellar-infra
+            component: fork-detector
+          annotations:
+            summary: "Potential network fork detected on {{ $labels.network }} node {{ $labels.node_id }}"
+            description: |
+              The local Stellar Core node ({{ $labels.node_id }}) on network
+              {{ $labels.network }} has had a ledger hash that diverges from the
+              public anchor majority for {{ $value }} consecutive ledger cycles.
+
+              This is a strong signal of a network fork, eclipse attack, or
+              misconfigured quorum set.
+
+              Immediate actions:
+              1. Check local Stellar Core /info: curl http://localhost:11626/info
+              2. Compare ledger hash with public explorers (stellar.expert, stellarbeat.io)
+              3. Check quorum set configuration
+              4. Review network connectivity and peer list
+              5. Check Stellar network status: https://dashboard.stellar.org
+            runbook_url: "https://github.com/stellar/stellar-k8s/blob/main/docs/QUICK_START_PEER_DISCOVERY.md"
+
+        # ── WARNING: Divergence starting ─────────────────────────────────────
+        - alert: StellarForkDivergenceWarning
+          expr: |
+            stellar_fork_detector_consecutive_diverging_ledgers >= 1
+            and
+            stellar_fork_detector_consecutive_diverging_ledgers < 3
+          for: 0m
+          labels:
+            severity: warning
+            team: stellar-infra
+            component: fork-detector
+          annotations:
+            summary: "Ledger hash divergence detected on {{ $labels.network }} node {{ $labels.node_id }}"
+            description: |
+              The local Stellar Core node ({{ $labels.node_id }}) has a ledger
+              hash that differs from the anchor majority for {{ $value }} ledger(s).
+              Monitoring for persistence (alert fires at 3 consecutive ledgers).
+
+        # ── WARNING: Low sync confidence ─────────────────────────────────────
+        - alert: StellarForkLowSyncConfidence
+          expr: |
+            stellar_fork_detector_sync_confidence < 500
+          for: 2m
+          labels:
+            severity: warning
+            team: stellar-infra
+            component: fork-detector
+          annotations:
+            summary: "Low sync confidence on {{ $labels.network }} node {{ $labels.node_id }}"
+            description: |
+              Sync confidence is {{ $value | humanize }}‰ (below 50%).
+              Fewer than half of the anchor nodes agree with the local ledger hash.
+              This may indicate anchor connectivity issues or a developing fork.
+
+        # ── WARNING: No anchors responding ───────────────────────────────────
+        - alert: StellarForkNoAnchorsResponding
+          expr: |
+            stellar_fork_detector_responding_anchors == 0
+          for: 5m
+          labels:
+            severity: warning
+            team: stellar-infra
+            component: fork-detector
+          annotations:
+            summary: "No anchor nodes responding for {{ $labels.network }} node {{ $labels.node_id }}"
+            description: |
+              The fork detector cannot reach any public anchor nodes.
+              Fork detection is degraded — cannot confirm or deny divergence.
+              Check network egress connectivity from the pod.
+
+        # ── INFO: Critical CVE alert ──────────────────────────────────────────
+        - alert: StellarCriticalCVEDetected
+          expr: |
+            increase(stellar_cve_critical_alerts_total[1h]) > 0
+          for: 0m
+          labels:
+            severity: critical
+            team: stellar-infra
+            component: cve-scanner
+          annotations:
+            summary: "Critical CVE detected in operator-managed pods"
+            description: |
+              The CVE scanner has detected one or more critical vulnerabilities
+              in images used by operator-managed pods in the last hour.
+              Run 'kubectl stellar cve list --severity critical' to see affected pods.

--- a/src/bin/stellar-fork-detector.rs
+++ b/src/bin/stellar-fork-detector.rs
@@ -1,0 +1,136 @@
+//! `stellar-fork-detector` — Fork Detection Sidecar binary.
+//!
+//! Monitors the local Stellar Core ledger hash and compares it in real-time
+//! against multiple public anchor nodes to detect potential network forks.
+//!
+//! # Usage
+//!
+//! ```text
+//! stellar-fork-detector \
+//!   --local-endpoint http://localhost:11626 \
+//!   --anchor https://horizon.stellar.org/ledgers?order=desc&limit=1 \
+//!   --anchor https://horizon-testnet.stellar.org/ledgers?order=desc&limit=1 \
+//!   --anchor https://horizon.stellar.lobstr.co/ledgers?order=desc&limit=1 \
+//!   --divergence-threshold 3 \
+//!   --metrics-bind 0.0.0.0:9102
+//! ```
+
+use anyhow::Result;
+use clap::Parser;
+use stellar_k8s::fork_detector::{run_fork_detector, ForkDetectorConfig};
+use tracing::info;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "stellar-fork-detector",
+    version,
+    about = "Fork Detection Sidecar — compares local ledger hash against public anchors",
+    long_about = "Runs as a sidecar alongside a Stellar Core node.\n\
+        Periodically fetches the latest ledger hash from the local Core and 3+ public\n\
+        anchor nodes. Alerts if a divergence persists for more than N consecutive ledgers.\n\
+        Exports 'stellar_fork_detector_sync_confidence' as a Prometheus metric.\n\n\
+        EXAMPLES:\n  \
+        stellar-fork-detector \\\n  \
+          --local-endpoint http://localhost:11626 \\\n  \
+          --anchor https://horizon.stellar.org/ledgers?order=desc&limit=1 \\\n  \
+          --anchor https://horizon.stellar.lobstr.co/ledgers?order=desc&limit=1 \\\n  \
+          --anchor https://horizon.satoshipay.io/ledgers?order=desc&limit=1"
+)]
+struct Args {
+    /// HTTP endpoint of the local Stellar Core node.
+    /// Env: FORK_DETECTOR_LOCAL_ENDPOINT
+    #[arg(
+        long,
+        env = "FORK_DETECTOR_LOCAL_ENDPOINT",
+        default_value = "http://localhost:11626"
+    )]
+    local_endpoint: String,
+
+    /// Public anchor node Horizon endpoints (repeat for multiple).
+    /// Env: FORK_DETECTOR_ANCHORS (comma-separated)
+    #[arg(long = "anchor", env = "FORK_DETECTOR_ANCHORS", value_delimiter = ',')]
+    anchors: Vec<String>,
+
+    /// How often to poll all nodes (seconds).
+    /// Env: FORK_DETECTOR_POLL_INTERVAL
+    #[arg(long, env = "FORK_DETECTOR_POLL_INTERVAL", default_value_t = 5)]
+    poll_interval: u64,
+
+    /// HTTP request timeout per node (seconds).
+    /// Env: FORK_DETECTOR_REQUEST_TIMEOUT
+    #[arg(long, env = "FORK_DETECTOR_REQUEST_TIMEOUT", default_value_t = 5)]
+    request_timeout: u64,
+
+    /// Number of consecutive diverging ledgers before firing a fork alert.
+    /// Env: FORK_DETECTOR_DIVERGENCE_THRESHOLD
+    #[arg(long, env = "FORK_DETECTOR_DIVERGENCE_THRESHOLD", default_value_t = 3)]
+    divergence_threshold: u64,
+
+    /// Address to bind the Prometheus /metrics HTTP server.
+    /// Env: FORK_DETECTOR_METRICS_BIND
+    #[arg(
+        long,
+        env = "FORK_DETECTOR_METRICS_BIND",
+        default_value = "0.0.0.0:9102"
+    )]
+    metrics_bind: String,
+
+    /// Stellar network name (for metric labels).
+    /// Env: FORK_DETECTOR_NETWORK
+    #[arg(long, env = "FORK_DETECTOR_NETWORK", default_value = "mainnet")]
+    network: String,
+
+    /// Node identifier (for metric labels).
+    /// Env: FORK_DETECTOR_NODE_ID
+    #[arg(long, env = "FORK_DETECTOR_NODE_ID", default_value = "local")]
+    node_id: String,
+
+    /// Log level (trace / debug / info / warn / error).
+    /// Env: RUST_LOG
+    #[arg(long, env = "RUST_LOG", default_value = "info")]
+    log_level: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    tracing_subscriber::registry()
+        .with(fmt::layer().json())
+        .with(EnvFilter::new(&args.log_level))
+        .init();
+
+    // Use default anchors if none provided.
+    let anchor_endpoints = if args.anchors.is_empty() {
+        vec![
+            "https://horizon.stellar.org/ledgers?order=desc&limit=1".to_string(),
+            "https://horizon.stellar.lobstr.co/ledgers?order=desc&limit=1".to_string(),
+            "https://horizon.satoshipay.io/ledgers?order=desc&limit=1".to_string(),
+        ]
+    } else {
+        args.anchors
+    };
+
+    info!(
+        node_id = %args.node_id,
+        network = %args.network,
+        local_endpoint = %args.local_endpoint,
+        anchors = anchor_endpoints.len(),
+        divergence_threshold = args.divergence_threshold,
+        "stellar-fork-detector starting"
+    );
+
+    let config = ForkDetectorConfig {
+        local_endpoint: args.local_endpoint,
+        anchor_endpoints,
+        poll_interval_secs: args.poll_interval,
+        request_timeout_secs: args.request_timeout,
+        divergence_threshold_ledgers: args.divergence_threshold,
+        metrics_bind_addr: args.metrics_bind,
+        network: args.network,
+        node_id: args.node_id,
+    };
+
+    run_fork_detector(config).await
+}

--- a/src/controller/cve_scanner.rs
+++ b/src/controller/cve_scanner.rs
@@ -1,0 +1,472 @@
+//! Background CVE Scanner
+//!
+//! Implements a background scanner that:
+//! 1. Periodically scans all images used by operator-managed pods.
+//! 2. Reports findings as Prometheus metrics and Kubernetes Events.
+//! 3. Alerts on Critical vulnerabilities in production namespaces.
+//!
+//! # Integration
+//!
+//! The scanner runs as a background task spawned by the operator at startup.
+//! It uses the Trivy HTTP API (or Grype if configured) to scan images.
+//!
+//! # Prometheus Metrics
+//!
+//! - `stellar_cve_vulnerabilities_total{image, severity}` — count per image/severity
+//! - `stellar_cve_scan_timestamp_seconds{image}` — last scan time
+//! - `stellar_cve_vulnerable_pods_total{namespace, severity}` — vulnerable pods per namespace
+//! - `stellar_cve_critical_alerts_total` — total critical alerts fired
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicI64, AtomicU64};
+use std::time::Duration;
+
+use k8s_openapi::api::core::v1::{Event, ObjectReference, Pod};
+use kube::{
+    api::{Api, ListParams, ObjectMeta, PostParams},
+    Client, ResourceExt,
+};
+use once_cell::sync::Lazy;
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use tokio::time::sleep;
+use tracing::{error, info, warn};
+
+use super::cve::{CVECount, RegistryScannerClient, VulnerabilitySeverity};
+use crate::error::Result;
+
+// ---------------------------------------------------------------------------
+// Prometheus metrics
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct CveScanLabels {
+    pub image: String,
+    pub severity: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct CveImageLabels {
+    pub image: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct CvePodLabels {
+    pub namespace: String,
+    pub severity: String,
+}
+
+/// Total vulnerabilities per image and severity.
+pub static CVE_VULNERABILITIES_TOTAL: Lazy<Family<CveScanLabels, Gauge<i64, AtomicI64>>> =
+    Lazy::new(Family::default);
+
+/// Unix timestamp of the last successful scan per image.
+pub static CVE_SCAN_TIMESTAMP: Lazy<Family<CveImageLabels, Gauge<i64, AtomicI64>>> =
+    Lazy::new(Family::default);
+
+/// Number of vulnerable pods per namespace and severity.
+pub static CVE_VULNERABLE_PODS_TOTAL: Lazy<Family<CvePodLabels, Gauge<i64, AtomicI64>>> =
+    Lazy::new(Family::default);
+
+/// Total critical alerts fired.
+pub static CVE_CRITICAL_ALERTS_TOTAL: Lazy<Counter<u64, AtomicU64>> =
+    Lazy::new(Counter::default);
+
+// ---------------------------------------------------------------------------
+// Scanner configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for the background CVE scanner.
+#[derive(Clone, Debug)]
+pub struct CveScannerConfig {
+    /// Trivy/Grype HTTP API endpoint.
+    pub scanner_endpoint: String,
+
+    /// How often to scan all images (seconds). Default: 3600 (1 hour).
+    pub scan_interval_secs: u64,
+
+    /// Namespaces to scan. Empty = all namespaces.
+    pub namespaces: Vec<String>,
+
+    /// Whether to fire Kubernetes Events for findings.
+    pub emit_k8s_events: bool,
+
+    /// Whether to alert on Critical vulnerabilities.
+    pub alert_on_critical: bool,
+}
+
+impl Default for CveScannerConfig {
+    fn default() -> Self {
+        Self {
+            scanner_endpoint: "http://trivy-api.security-scanning:8080".to_string(),
+            scan_interval_secs: 3600,
+            namespaces: vec![],
+            emit_k8s_events: true,
+            alert_on_critical: true,
+        }
+    }
+}
+
+/// Summary of a scan for one pod.
+#[derive(Debug, Clone)]
+pub struct PodScanSummary {
+    pub namespace: String,
+    pub pod_name: String,
+    pub image: String,
+    pub cve_count: CVECount,
+    pub has_critical: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Background scanner loop
+// ---------------------------------------------------------------------------
+
+/// Spawn the background CVE scanner. Returns immediately; scanning runs in background.
+pub fn spawn_background_scanner(client: Client, config: CveScannerConfig) {
+    tokio::spawn(async move {
+        loop {
+            if let Err(e) = run_scan_cycle(&client, &config).await {
+                error!("CVE scan cycle failed: {}", e);
+            }
+            sleep(Duration::from_secs(config.scan_interval_secs)).await;
+        }
+    });
+}
+
+/// Run one full scan cycle across all managed pods.
+pub async fn run_scan_cycle(client: &Client, config: &CveScannerConfig) -> Result<()> {
+    info!("Starting CVE scan cycle");
+
+    let scanner = RegistryScannerClient::new(config.scanner_endpoint.clone(), None);
+
+    // Collect all pods across configured namespaces.
+    let pods = collect_pods(client, &config.namespaces).await?;
+    info!("Scanning {} pods for CVEs", pods.len());
+
+    let mut summaries = Vec::new();
+
+    for pod in &pods {
+        let namespace = pod.namespace().unwrap_or_else(|| "default".to_string());
+        let pod_name = pod.name_any();
+
+        // Extract unique images from the pod spec.
+        let images = extract_pod_images(pod);
+
+        for image in images {
+            match scanner.scan_image(&image).await {
+                Ok(result) => {
+                    // Update Prometheus metrics.
+                    update_cve_metrics(&image, &result.cve_count);
+
+                    let summary = PodScanSummary {
+                        namespace: namespace.clone(),
+                        pod_name: pod_name.clone(),
+                        image: image.clone(),
+                        cve_count: result.cve_count.clone(),
+                        has_critical: result.has_critical,
+                    };
+
+                    if result.has_critical && config.alert_on_critical {
+                        fire_critical_alert(client, pod, &image, &result.cve_count).await;
+                    }
+
+                    if config.emit_k8s_events && result.cve_count.total() > 0 {
+                        emit_cve_event(client, pod, &image, &result.cve_count).await;
+                    }
+
+                    summaries.push(summary);
+                }
+                Err(e) => {
+                    warn!("Failed to scan image {} in pod {}/{}: {}", image, namespace, pod_name, e);
+                }
+            }
+        }
+    }
+
+    // Update per-namespace vulnerable pod counts.
+    update_namespace_metrics(&summaries);
+
+    info!(
+        "CVE scan cycle complete: {} pods scanned, {} with critical vulnerabilities",
+        summaries.len(),
+        summaries.iter().filter(|s| s.has_critical).count()
+    );
+
+    Ok(())
+}
+
+/// Collect all pods from the specified namespaces (or all namespaces if empty).
+async fn collect_pods(client: &Client, namespaces: &[String]) -> Result<Vec<Pod>> {
+    let mut all_pods = Vec::new();
+
+    if namespaces.is_empty() {
+        // All namespaces.
+        let pods_api: Api<Pod> = Api::all(client.clone());
+        let pods = pods_api
+            .list(&ListParams::default().labels("app.kubernetes.io/managed-by=stellar-operator"))
+            .await?;
+        all_pods.extend(pods.items);
+    } else {
+        for ns in namespaces {
+            let pods_api: Api<Pod> = Api::namespaced(client.clone(), ns);
+            let pods = pods_api
+                .list(&ListParams::default().labels("app.kubernetes.io/managed-by=stellar-operator"))
+                .await?;
+            all_pods.extend(pods.items);
+        }
+    }
+
+    Ok(all_pods)
+}
+
+/// Extract all unique container images from a pod.
+fn extract_pod_images(pod: &Pod) -> Vec<String> {
+    let mut images = Vec::new();
+
+    if let Some(spec) = &pod.spec {
+        for container in &spec.containers {
+            if let Some(image) = &container.image {
+                if !images.contains(image) {
+                    images.push(image.clone());
+                }
+            }
+        }
+        for container in spec.init_containers.iter().flatten() {
+            if let Some(image) = &container.image {
+                if !images.contains(image) {
+                    images.push(image.clone());
+                }
+            }
+        }
+    }
+
+    images
+}
+
+/// Update Prometheus CVE metrics for a scanned image.
+fn update_cve_metrics(image: &str, counts: &CVECount) {
+    let now = chrono::Utc::now().timestamp();
+    CVE_SCAN_TIMESTAMP
+        .get_or_create(&CveImageLabels {
+            image: image.to_string(),
+        })
+        .set(now);
+
+    for (severity, count) in [
+        ("CRITICAL", counts.critical as i64),
+        ("HIGH", counts.high as i64),
+        ("MEDIUM", counts.medium as i64),
+        ("LOW", counts.low as i64),
+    ] {
+        CVE_VULNERABILITIES_TOTAL
+            .get_or_create(&CveScanLabels {
+                image: image.to_string(),
+                severity: severity.to_string(),
+            })
+            .set(count);
+    }
+}
+
+/// Update per-namespace vulnerable pod counts.
+fn update_namespace_metrics(summaries: &[PodScanSummary]) {
+    // Group by namespace.
+    let mut ns_critical: BTreeMap<String, i64> = BTreeMap::new();
+    let mut ns_high: BTreeMap<String, i64> = BTreeMap::new();
+
+    for s in summaries {
+        if s.cve_count.critical > 0 {
+            *ns_critical.entry(s.namespace.clone()).or_default() += 1;
+        }
+        if s.cve_count.high > 0 {
+            *ns_high.entry(s.namespace.clone()).or_default() += 1;
+        }
+    }
+
+    for (ns, count) in ns_critical {
+        CVE_VULNERABLE_PODS_TOTAL
+            .get_or_create(&CvePodLabels {
+                namespace: ns,
+                severity: "CRITICAL".to_string(),
+            })
+            .set(count);
+    }
+    for (ns, count) in ns_high {
+        CVE_VULNERABLE_PODS_TOTAL
+            .get_or_create(&CvePodLabels {
+                namespace: ns,
+                severity: "HIGH".to_string(),
+            })
+            .set(count);
+    }
+}
+
+/// Fire a critical CVE alert: log at ERROR level and increment the alert counter.
+async fn fire_critical_alert(client: &Client, pod: &Pod, image: &str, counts: &CVECount) {
+    let namespace = pod.namespace().unwrap_or_else(|| "default".to_string());
+    let pod_name = pod.name_any();
+
+    CVE_CRITICAL_ALERTS_TOTAL.inc();
+
+    error!(
+        namespace = %namespace,
+        pod = %pod_name,
+        image = %image,
+        critical_cves = counts.critical,
+        high_cves = counts.high,
+        "CRITICAL CVE ALERT: Pod is running an image with {} critical vulnerabilities. \
+         Immediate remediation required.",
+        counts.critical
+    );
+
+    // Also emit a Warning Kubernetes Event.
+    emit_cve_event(client, pod, image, counts).await;
+}
+
+/// Emit a Kubernetes Event on the pod describing the CVE findings.
+async fn emit_cve_event(client: &Client, pod: &Pod, image: &str, counts: &CVECount) {
+    let namespace = pod.namespace().unwrap_or_else(|| "default".to_string());
+    let pod_name = pod.name_any();
+
+    let severity_label = if counts.critical > 0 {
+        "Critical"
+    } else if counts.high > 0 {
+        "High"
+    } else {
+        "Medium"
+    };
+
+    let message = format!(
+        "CVE scan found vulnerabilities in image '{}': {} critical, {} high, {} medium, {} low. \
+         Review and update the image to a patched version.",
+        image, counts.critical, counts.high, counts.medium, counts.low
+    );
+
+    let event_type = if counts.critical > 0 { "Warning" } else { "Normal" };
+
+    let now = chrono::Utc::now();
+    let event = Event {
+        metadata: ObjectMeta {
+            name: Some(format!(
+                "{}-cve-{}-{}",
+                pod_name,
+                severity_label.to_lowercase(),
+                now.timestamp()
+            )),
+            namespace: Some(namespace.clone()),
+            ..Default::default()
+        },
+        action: Some("CVEScan".to_string()),
+        event_time: None,
+        first_timestamp: Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
+            now.into(),
+        )),
+        last_timestamp: Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
+            now.into(),
+        )),
+        involved_object: ObjectReference {
+            api_version: Some("v1".to_string()),
+            kind: Some("Pod".to_string()),
+            name: Some(pod_name.clone()),
+            namespace: Some(namespace.clone()),
+            uid: pod.metadata.uid.clone(),
+            ..Default::default()
+        },
+        message: Some(message),
+        reason: Some(format!("CVE{}", severity_label)),
+        reporting_component: Some("stellar-operator/cve-scanner".to_string()),
+        reporting_instance: Some(
+            std::env::var("POD_NAME").unwrap_or_else(|_| "stellar-operator".to_string()),
+        ),
+        source: Some(k8s_openapi::api::core::v1::EventSource {
+            component: Some("stellar-operator".to_string()),
+            host: None,
+        }),
+        type_: Some(event_type.to_string()),
+        count: Some(1),
+        series: None,
+        related: None,
+    };
+
+    let events_api: Api<Event> = Api::namespaced(client.clone(), &namespace);
+    if let Err(e) = events_api.create(&PostParams::default(), &event).await {
+        warn!("Failed to emit CVE event for pod {}/{}: {}", namespace, pod_name, e);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CLI: list vulnerable pods
+// ---------------------------------------------------------------------------
+
+/// List all pods with CVE findings above the given minimum severity.
+/// Used by the `kubectl stellar cve list` CLI command.
+pub async fn list_vulnerable_pods(
+    client: &Client,
+    config: &CveScannerConfig,
+    min_severity: VulnerabilitySeverity,
+) -> Result<Vec<PodScanSummary>> {
+    let scanner = RegistryScannerClient::new(config.scanner_endpoint.clone(), None);
+    let pods = collect_pods(client, &config.namespaces).await?;
+
+    let mut results = Vec::new();
+
+    for pod in &pods {
+        let namespace = pod.namespace().unwrap_or_else(|| "default".to_string());
+        let pod_name = pod.name_any();
+        let images = extract_pod_images(pod);
+
+        for image in images {
+            if let Ok(scan) = scanner.scan_image(&image).await {
+                let qualifies = match min_severity {
+                    VulnerabilitySeverity::Critical => scan.cve_count.critical > 0,
+                    VulnerabilitySeverity::High => {
+                        scan.cve_count.critical > 0 || scan.cve_count.high > 0
+                    }
+                    VulnerabilitySeverity::Medium => {
+                        scan.cve_count.critical > 0
+                            || scan.cve_count.high > 0
+                            || scan.cve_count.medium > 0
+                    }
+                    _ => scan.cve_count.total() > 0,
+                };
+
+                if qualifies {
+                    results.push(PodScanSummary {
+                        namespace: namespace.clone(),
+                        pod_name: pod_name.clone(),
+                        image: image.clone(),
+                        cve_count: scan.cve_count,
+                        has_critical: scan.has_critical,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+/// Register CVE scanner metrics into an existing Prometheus registry.
+pub fn register_cve_metrics(registry: &mut prometheus_client::registry::Registry) {
+    registry.register(
+        "stellar_cve_vulnerabilities_total",
+        "Number of CVE vulnerabilities found per image and severity level.",
+        CVE_VULNERABILITIES_TOTAL.clone(),
+    );
+    registry.register(
+        "stellar_cve_scan_timestamp_seconds",
+        "Unix timestamp of the last successful CVE scan per image.",
+        CVE_SCAN_TIMESTAMP.clone(),
+    );
+    registry.register(
+        "stellar_cve_vulnerable_pods_total",
+        "Number of pods with CVE vulnerabilities per namespace and severity.",
+        CVE_VULNERABLE_PODS_TOTAL.clone(),
+    );
+    registry.register(
+        "stellar_cve_critical_alerts_total",
+        "Total number of critical CVE alerts fired since operator start.",
+        CVE_CRITICAL_ALERTS_TOTAL.clone(),
+    );
+}

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -78,6 +78,7 @@ pub mod cost;
 pub mod cross_cluster;
 pub mod cve;
 pub(crate) mod cve_reconciler;
+pub mod cve_scanner;
 #[cfg(test)]
 pub(crate) mod cve_test;
 pub mod db_pool;
@@ -141,6 +142,10 @@ pub use blue_green::{
 pub use cross_cloud_failover::reconcile_cross_cloud_failover;
 pub use cross_cluster::{check_peer_latency, ensure_cross_cluster_services, PeerLatencyStatus};
 pub use cve_reconciler::reconcile_cve_patches;
+pub use cve_scanner::{
+    list_vulnerable_pods, register_cve_metrics, spawn_background_scanner, CveScannerConfig,
+    PodScanSummary,
+};
 pub use db_pool::{
     create_pool, DbPoolConfig, DEFAULT_CONNECTION_TIMEOUT_SECS, DEFAULT_MAX_CONNECTIONS,
 };

--- a/src/fork_detector/detector.rs
+++ b/src/fork_detector/detector.rs
@@ -1,0 +1,395 @@
+//! Core fork detection logic.
+//!
+//! Polls the local Stellar Core node and multiple public anchor nodes,
+//! compares ledger hashes, and fires alerts when divergence persists.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::Router;
+use futures::future::join_all;
+use prometheus_client::encoding::text::encode;
+use reqwest::Client;
+use tokio::sync::RwLock;
+use tokio::time::sleep;
+use tracing::{error, info, warn};
+
+use super::metrics::{
+    build_registry, CONSECUTIVE_DIVERGING_LEDGERS, FORK_ALERTS_TOTAL, LOCAL_LEDGER_SEQUENCE,
+    POLL_ERRORS_TOTAL, RESPONDING_ANCHORS, SYNC_CONFIDENCE,
+};
+use super::types::{
+    ForkCheckResult, ForkDetectorConfig, HorizonLedgersResponse, LedgerObservation,
+    StellarCoreInfoResponse,
+};
+
+/// Shared state for the fork detector.
+struct DetectorState {
+    config: ForkDetectorConfig,
+    /// Number of consecutive cycles where divergence was detected.
+    consecutive_diverging: u64,
+    /// Prometheus registry.
+    registry: prometheus_client::registry::Registry,
+}
+
+impl DetectorState {
+    fn new(config: ForkDetectorConfig) -> Self {
+        let registry = build_registry();
+        Self {
+            config,
+            consecutive_diverging: 0,
+            registry,
+        }
+    }
+
+    fn labels(&self) -> super::metrics::ForkDetectorLabels {
+        super::metrics::ForkDetectorLabels {
+            network: self.config.network.clone(),
+            node_id: self.config.node_id.clone(),
+        }
+    }
+}
+
+/// Entry point — starts the metrics HTTP server and the detection loop.
+pub async fn run_fork_detector(config: ForkDetectorConfig) -> Result<()> {
+    info!(
+        node_id = %config.node_id,
+        network = %config.network,
+        local_endpoint = %config.local_endpoint,
+        anchors = config.anchor_endpoints.len(),
+        poll_interval_secs = config.poll_interval_secs,
+        divergence_threshold = config.divergence_threshold_ledgers,
+        "Starting Stellar Fork Detector sidecar"
+    );
+
+    let state = Arc::new(RwLock::new(DetectorState::new(config.clone())));
+
+    let http_client = Client::builder()
+        .timeout(Duration::from_secs(config.request_timeout_secs))
+        .user_agent("stellar-fork-detector/1.0")
+        .build()
+        .context("Failed to build HTTP client")?;
+
+    // Spawn metrics server.
+    let server_state = Arc::clone(&state);
+    let metrics_addr = config.metrics_bind_addr.clone();
+    tokio::spawn(async move {
+        if let Err(e) = serve_metrics(server_state, &metrics_addr).await {
+            error!("Fork detector metrics server error: {}", e);
+        }
+    });
+
+    // Detection loop.
+    let poll_interval = Duration::from_secs(config.poll_interval_secs);
+    loop {
+        match run_detection_cycle(&http_client, &config).await {
+            Ok(result) => {
+                let mut st = state.write().await;
+                update_state_and_metrics(&mut st, &result);
+            }
+            Err(e) => {
+                warn!("Fork detection cycle error: {}", e);
+                let st = state.read().await;
+                POLL_ERRORS_TOTAL
+                    .get_or_create(&st.labels())
+                    .inc();
+            }
+        }
+        sleep(poll_interval).await;
+    }
+}
+
+/// Run one detection cycle: poll local + all anchors, compare hashes.
+async fn run_detection_cycle(
+    client: &Client,
+    config: &ForkDetectorConfig,
+) -> Result<ForkCheckResult> {
+    // Poll local node.
+    let local_obs = poll_local_core(client, &config.local_endpoint).await;
+
+    let (local_sequence, local_hash) = match &local_obs {
+        Some(obs) if obs.ok => (obs.sequence, obs.hash.clone()),
+        _ => {
+            anyhow::bail!("Local Stellar Core node is unreachable or not synced");
+        }
+    };
+
+    // Poll all anchors concurrently.
+    let anchor_futs: Vec<_> = config
+        .anchor_endpoints
+        .iter()
+        .map(|ep| poll_anchor(client, ep, local_sequence))
+        .collect();
+
+    let anchor_results = join_all(anchor_futs).await;
+
+    let responding: Vec<&LedgerObservation> = anchor_results.iter().filter(|o| o.ok).collect();
+    let agreeing = responding
+        .iter()
+        .filter(|o| o.hash == local_hash)
+        .count();
+
+    let responding_count = responding.len();
+    let sync_confidence = if responding_count == 0 {
+        // No anchors reachable — can't determine confidence; treat as 1.0 (no evidence of fork)
+        1.0_f64
+    } else {
+        agreeing as f64 / responding_count as f64
+    };
+
+    // Divergence = majority of responding anchors disagree with local hash.
+    let divergence_detected = responding_count > 0 && agreeing < (responding_count + 1) / 2;
+
+    Ok(ForkCheckResult {
+        local_sequence,
+        local_hash,
+        agreeing_anchors: agreeing,
+        responding_anchors: responding_count,
+        divergence_detected,
+        sync_confidence,
+    })
+}
+
+/// Update in-memory state and Prometheus metrics after a detection cycle.
+fn update_state_and_metrics(st: &mut DetectorState, result: &ForkCheckResult) {
+    let labels = st.labels();
+
+    // Update sequence and confidence metrics.
+    LOCAL_LEDGER_SEQUENCE
+        .get_or_create(&labels)
+        .set(result.local_sequence as i64);
+
+    // Encode confidence as millipercent (0–1000) to avoid float in Prometheus gauge.
+    let confidence_mp = (result.sync_confidence * 1000.0) as i64;
+    SYNC_CONFIDENCE.get_or_create(&labels).set(confidence_mp);
+
+    RESPONDING_ANCHORS
+        .get_or_create(&labels)
+        .set(result.responding_anchors as i64);
+
+    if result.divergence_detected {
+        st.consecutive_diverging += 1;
+        CONSECUTIVE_DIVERGING_LEDGERS
+            .get_or_create(&labels)
+            .set(st.consecutive_diverging as i64);
+
+        warn!(
+            sequence = result.local_sequence,
+            local_hash = %result.local_hash,
+            agreeing = result.agreeing_anchors,
+            responding = result.responding_anchors,
+            consecutive = st.consecutive_diverging,
+            confidence_pct = format!("{:.1}%", result.sync_confidence * 100.0),
+            "Fork divergence detected"
+        );
+
+        // Fire alert if divergence persists beyond threshold.
+        if st.consecutive_diverging >= st.config.divergence_threshold_ledgers {
+            FORK_ALERTS_TOTAL.get_or_create(&labels).inc();
+            error!(
+                sequence = result.local_sequence,
+                local_hash = %result.local_hash,
+                consecutive_diverging = st.consecutive_diverging,
+                threshold = st.config.divergence_threshold_ledgers,
+                network = %st.config.network,
+                node_id = %st.config.node_id,
+                "FORK ALERT: Local ledger hash has diverged from anchor majority for {} consecutive ledgers. \
+                 Possible network fork detected. Investigate immediately.",
+                st.consecutive_diverging
+            );
+        }
+    } else {
+        // Reset consecutive counter on agreement.
+        if st.consecutive_diverging > 0 {
+            info!(
+                sequence = result.local_sequence,
+                "Fork divergence resolved after {} consecutive diverging ledgers",
+                st.consecutive_diverging
+            );
+        }
+        st.consecutive_diverging = 0;
+        CONSECUTIVE_DIVERGING_LEDGERS
+            .get_or_create(&labels)
+            .set(0);
+    }
+
+    info!(
+        sequence = result.local_sequence,
+        agreeing = result.agreeing_anchors,
+        responding = result.responding_anchors,
+        confidence_pct = format!("{:.1}%", result.sync_confidence * 100.0),
+        divergence = result.divergence_detected,
+        "Fork detection cycle complete"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Node polling helpers
+// ---------------------------------------------------------------------------
+
+/// Poll the local Stellar Core `/info` endpoint.
+async fn poll_local_core(client: &Client, endpoint: &str) -> Option<LedgerObservation> {
+    let url = format!("{}/info", endpoint.trim_end_matches('/'));
+    match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            match resp.json::<StellarCoreInfoResponse>().await {
+                Ok(info) => {
+                    let state_lower = info.info.state.to_lowercase();
+                    let synced =
+                        state_lower.contains("synced") || state_lower.contains("externalize");
+                    if !synced {
+                        warn!(state = %info.info.state, "Local node not yet synced");
+                        return None;
+                    }
+                    Some(LedgerObservation {
+                        source: endpoint.to_string(),
+                        sequence: info.info.ledger.num,
+                        hash: info.info.ledger.hash,
+                        ok: true,
+                    })
+                }
+                Err(e) => {
+                    warn!("Failed to parse local core /info response: {}", e);
+                    None
+                }
+            }
+        }
+        Ok(resp) => {
+            warn!("Local core /info returned HTTP {}", resp.status());
+            None
+        }
+        Err(e) => {
+            warn!("Failed to reach local core at {}: {}", url, e);
+            None
+        }
+    }
+}
+
+/// Poll a Horizon anchor endpoint for the latest ledger at or near `target_sequence`.
+/// Horizon's `/ledgers?order=desc&limit=1` returns the most recent ledger.
+async fn poll_anchor(
+    client: &Client,
+    endpoint: &str,
+    _target_sequence: u64,
+) -> LedgerObservation {
+    // Horizon public API: GET /ledgers?order=desc&limit=1
+    let url = if endpoint.contains("/ledgers") {
+        endpoint.to_string()
+    } else {
+        format!(
+            "{}/ledgers?order=desc&limit=1",
+            endpoint.trim_end_matches('/')
+        )
+    };
+
+    match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            match resp.json::<HorizonLedgersResponse>().await {
+                Ok(data) => {
+                    if let Some(ledger) = data.embedded.records.first() {
+                        return LedgerObservation {
+                            source: endpoint.to_string(),
+                            sequence: ledger.sequence,
+                            hash: ledger.hash.clone(),
+                            ok: true,
+                        };
+                    }
+                    warn!("Anchor {} returned empty ledger list", endpoint);
+                    LedgerObservation {
+                        source: endpoint.to_string(),
+                        sequence: 0,
+                        hash: String::new(),
+                        ok: false,
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to parse anchor {} response: {}", endpoint, e);
+                    LedgerObservation {
+                        source: endpoint.to_string(),
+                        sequence: 0,
+                        hash: String::new(),
+                        ok: false,
+                    }
+                }
+            }
+        }
+        Ok(resp) => {
+            warn!("Anchor {} returned HTTP {}", endpoint, resp.status());
+            LedgerObservation {
+                source: endpoint.to_string(),
+                sequence: 0,
+                hash: String::new(),
+                ok: false,
+            }
+        }
+        Err(e) => {
+            warn!("Failed to reach anchor {}: {}", endpoint, e);
+            LedgerObservation {
+                source: endpoint.to_string(),
+                sequence: 0,
+                hash: String::new(),
+                ok: false,
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Metrics HTTP server
+// ---------------------------------------------------------------------------
+
+type SharedState = Arc<RwLock<DetectorState>>;
+
+async fn serve_metrics(state: SharedState, bind_addr: &str) -> Result<()> {
+    let app = Router::new()
+        .route("/metrics", get(metrics_handler))
+        .route("/healthz", get(health_handler))
+        .route("/readyz", get(ready_handler))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(bind_addr)
+        .await
+        .with_context(|| format!("Failed to bind fork detector metrics server to {}", bind_addr))?;
+
+    info!("Fork detector metrics server listening on http://{}", bind_addr);
+
+    axum::serve(listener, app)
+        .await
+        .context("Fork detector metrics server error")?;
+
+    Ok(())
+}
+
+async fn metrics_handler(State(state): State<SharedState>) -> impl IntoResponse {
+    let st = state.read().await;
+    let mut buf = String::new();
+    if let Err(e) = encode(&mut buf, &st.registry) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to encode metrics: {}", e),
+        );
+    }
+    (StatusCode::OK, buf)
+}
+
+async fn health_handler(_state: State<SharedState>) -> impl IntoResponse {
+    (StatusCode::OK, "OK")
+}
+
+async fn ready_handler(State(state): State<SharedState>) -> impl IntoResponse {
+    let st = state.read().await;
+    // Ready once we have at least one successful poll (consecutive_diverging was set or reset).
+    // We use the local sequence metric as a proxy.
+    let labels = st.labels();
+    let seq = LOCAL_LEDGER_SEQUENCE.get_or_create(&labels).get();
+    if seq > 0 {
+        (StatusCode::OK, "Ready")
+    } else {
+        (StatusCode::SERVICE_UNAVAILABLE, "Not ready yet")
+    }
+}

--- a/src/fork_detector/metrics.rs
+++ b/src/fork_detector/metrics.rs
@@ -1,0 +1,81 @@
+//! Prometheus metrics for the fork detection sidecar.
+
+use std::sync::atomic::{AtomicI64, AtomicU64};
+
+use once_cell::sync::Lazy;
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::registry::Registry;
+
+/// Labels for fork detector metrics.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct ForkDetectorLabels {
+    pub network: String,
+    pub node_id: String,
+}
+
+/// Sync confidence gauge (0.0–1.0 encoded as integer millipercent: 0–1000).
+/// Use `sync_confidence / 1000.0` to get the float value in Grafana.
+pub static SYNC_CONFIDENCE: Lazy<Family<ForkDetectorLabels, Gauge<i64, AtomicI64>>> =
+    Lazy::new(Family::default);
+
+/// Number of consecutive diverging ledgers.
+pub static CONSECUTIVE_DIVERGING_LEDGERS: Lazy<Family<ForkDetectorLabels, Gauge<i64, AtomicI64>>> =
+    Lazy::new(Family::default);
+
+/// Total fork alerts fired.
+pub static FORK_ALERTS_TOTAL: Lazy<Family<ForkDetectorLabels, Counter<u64, AtomicU64>>> =
+    Lazy::new(Family::default);
+
+/// Total poll errors (local + anchors combined).
+pub static POLL_ERRORS_TOTAL: Lazy<Family<ForkDetectorLabels, Counter<u64, AtomicU64>>> =
+    Lazy::new(Family::default);
+
+/// Current local ledger sequence.
+pub static LOCAL_LEDGER_SEQUENCE: Lazy<Family<ForkDetectorLabels, Gauge<i64, AtomicI64>>> =
+    Lazy::new(Family::default);
+
+/// Number of responding anchors in the last poll.
+pub static RESPONDING_ANCHORS: Lazy<Family<ForkDetectorLabels, Gauge<i64, AtomicI64>>> =
+    Lazy::new(Family::default);
+
+/// Build and return a fresh Prometheus registry with all fork detector metrics registered.
+pub fn build_registry() -> Registry {
+    let mut registry = Registry::default();
+
+    registry.register(
+        "stellar_fork_detector_sync_confidence",
+        "Sync confidence as millipercent (0–1000). Divide by 1000 for 0.0–1.0 float. \
+         Fraction of anchor nodes that agree with the local ledger hash.",
+        SYNC_CONFIDENCE.clone(),
+    );
+    registry.register(
+        "stellar_fork_detector_consecutive_diverging_ledgers",
+        "Number of consecutive ledger cycles where the local hash diverged from the anchor majority.",
+        CONSECUTIVE_DIVERGING_LEDGERS.clone(),
+    );
+    registry.register(
+        "stellar_fork_detector_fork_alerts_total",
+        "Total number of fork alerts fired (divergence persisted beyond threshold).",
+        FORK_ALERTS_TOTAL.clone(),
+    );
+    registry.register(
+        "stellar_fork_detector_poll_errors_total",
+        "Total number of failed polls across local node and all anchors.",
+        POLL_ERRORS_TOTAL.clone(),
+    );
+    registry.register(
+        "stellar_fork_detector_local_ledger_sequence",
+        "Latest ledger sequence observed from the local Stellar Core node.",
+        LOCAL_LEDGER_SEQUENCE.clone(),
+    );
+    registry.register(
+        "stellar_fork_detector_responding_anchors",
+        "Number of anchor nodes that responded successfully in the last poll cycle.",
+        RESPONDING_ANCHORS.clone(),
+    );
+
+    registry
+}

--- a/src/fork_detector/mod.rs
+++ b/src/fork_detector/mod.rs
@@ -1,0 +1,20 @@
+//! Fork Detection Sidecar
+//!
+//! Monitors the local Stellar Core ledger hash and compares it in real-time
+//! against multiple public anchor nodes to detect potential network forks.
+//!
+//! # Architecture
+//!
+//! - Polls the local Stellar Core node (`/info`) every `poll_interval_secs`.
+//! - Concurrently polls 3+ public anchor nodes.
+//! - Compares the local hash against the anchor majority hash at the same ledger sequence.
+//! - If divergence persists for more than `divergence_threshold_ledgers` consecutive ledgers,
+//!   fires an alert (log + Prometheus metric + Kubernetes Event).
+//! - Exports `stellar_fork_detector_sync_confidence` as a Prometheus gauge (0.0–1.0).
+
+pub mod detector;
+pub mod metrics;
+pub mod types;
+
+pub use detector::run_fork_detector;
+pub use types::ForkDetectorConfig;

--- a/src/fork_detector/types.rs
+++ b/src/fork_detector/types.rs
@@ -1,0 +1,117 @@
+//! Types for the fork detection sidecar.
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the fork detector sidecar.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ForkDetectorConfig {
+    /// HTTP endpoint of the local Stellar Core node.
+    /// Default: `http://localhost:11626`
+    pub local_endpoint: String,
+
+    /// Public anchor node endpoints to compare against (minimum 3 recommended).
+    pub anchor_endpoints: Vec<String>,
+
+    /// How often to poll all nodes (seconds). Default: 5.
+    pub poll_interval_secs: u64,
+
+    /// HTTP request timeout per node (seconds). Default: 5.
+    pub request_timeout_secs: u64,
+
+    /// Number of consecutive diverging ledgers before alerting. Default: 3.
+    pub divergence_threshold_ledgers: u64,
+
+    /// Address to bind the Prometheus /metrics HTTP server. Default: `0.0.0.0:9102`
+    pub metrics_bind_addr: String,
+
+    /// Stellar network name (for labels). Default: `mainnet`
+    pub network: String,
+
+    /// Node identifier (for labels). Default: `local`
+    pub node_id: String,
+}
+
+impl Default for ForkDetectorConfig {
+    fn default() -> Self {
+        Self {
+            local_endpoint: "http://localhost:11626".to_string(),
+            anchor_endpoints: vec![
+                "https://horizon.stellar.org/ledgers?order=desc&limit=1".to_string(),
+                "https://horizon-testnet.stellar.org/ledgers?order=desc&limit=1".to_string(),
+                "https://stellar.expert/explorer/public/ledger".to_string(),
+            ],
+            poll_interval_secs: 5,
+            request_timeout_secs: 5,
+            divergence_threshold_ledgers: 3,
+            metrics_bind_addr: "0.0.0.0:9102".to_string(),
+            network: "mainnet".to_string(),
+            node_id: "local".to_string(),
+        }
+    }
+}
+
+/// A single ledger observation from one node.
+#[derive(Clone, Debug)]
+pub struct LedgerObservation {
+    /// Source identifier (local / anchor URL).
+    pub source: String,
+    /// Ledger sequence number.
+    pub sequence: u64,
+    /// Hex-encoded ledger close hash.
+    pub hash: String,
+    /// Whether the fetch succeeded.
+    pub ok: bool,
+}
+
+/// Aggregated comparison result for one poll cycle.
+#[derive(Clone, Debug)]
+pub struct ForkCheckResult {
+    /// Local ledger sequence.
+    pub local_sequence: u64,
+    /// Local ledger hash.
+    pub local_hash: String,
+    /// Number of anchors that agree with the local hash (at the same sequence).
+    pub agreeing_anchors: usize,
+    /// Total anchors that responded.
+    pub responding_anchors: usize,
+    /// Whether a fork divergence was detected this cycle.
+    pub divergence_detected: bool,
+    /// Sync confidence: agreeing_anchors / responding_anchors (0.0–1.0).
+    pub sync_confidence: f64,
+}
+
+/// Response from Stellar Core `/info` endpoint (subset).
+#[derive(Debug, Deserialize)]
+pub struct StellarCoreInfoResponse {
+    pub info: StellarCoreInfo,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StellarCoreInfo {
+    pub ledger: StellarCoreLedger,
+    pub state: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StellarCoreLedger {
+    pub num: u64,
+    pub hash: String,
+}
+
+/// Response from Horizon `/ledgers?order=desc&limit=1`.
+#[derive(Debug, Deserialize)]
+pub struct HorizonLedgersResponse {
+    #[serde(rename = "_embedded")]
+    pub embedded: HorizonEmbedded,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HorizonEmbedded {
+    pub records: Vec<HorizonLedger>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HorizonLedger {
+    pub sequence: u64,
+    pub hash: String,
+}

--- a/src/kubectl_plugin.rs
+++ b/src/kubectl_plugin.rs
@@ -173,6 +173,11 @@ enum Commands {
         #[arg(short = 'A', long)]
         all_namespaces: bool,
     },
+    /// List pods with CVE vulnerabilities detected by the background scanner
+    Cve {
+        #[command(subcommand)]
+        command: CveCommands,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -193,6 +198,19 @@ pub enum AuditCommands {
     Show {
         /// Audit entry ID
         id: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum CveCommands {
+    /// List all pods with CVE vulnerabilities
+    List {
+        /// Minimum severity to show (critical, high, medium, low)
+        #[arg(short, long, default_value = "high")]
+        severity: String,
+        /// Show all namespaces
+        #[arg(short = 'A', long)]
+        all_namespaces: bool,
     },
 }
 
@@ -221,7 +239,8 @@ async fn run(cli: Cli) -> Result<()> {
             | Commands::Explain { .. }
             | Commands::Search { .. }
             | Commands::Completions { .. }
-            | Commands::Summary { .. } => None,
+            | Commands::Summary { .. }
+            | Commands::Cve { .. } => None,
             Commands::Logs { node_name, .. } => Some(format!(
                 "Stream logs from StellarNode '{node_name}' (read-only, no cluster mutation)"
             )),
@@ -433,6 +452,80 @@ async fn run(cli: Cli) -> Result<()> {
                 &cli.output,
             )
             .await
+        }
+        Commands::Cve { command } => {
+            let client = Client::try_default().await.map_err(Error::KubeError)?;
+            match command {
+                CveCommands::List {
+                    severity,
+                    all_namespaces,
+                } => {
+                    use stellar_k8s::controller::cve::VulnerabilitySeverity;
+                    use stellar_k8s::controller::{list_vulnerable_pods, CveScannerConfig};
+
+                    let min_severity = match severity.to_lowercase().as_str() {
+                        "critical" => VulnerabilitySeverity::Critical,
+                        "high" => VulnerabilitySeverity::High,
+                        "medium" => VulnerabilitySeverity::Medium,
+                        _ => VulnerabilitySeverity::Low,
+                    };
+
+                    let namespaces = if all_namespaces {
+                        vec![]
+                    } else {
+                        cli.namespace
+                            .as_deref()
+                            .map(|ns| vec![ns.to_string()])
+                            .unwrap_or_default()
+                    };
+
+                    let scanner_endpoint = std::env::var("TRIVY_API_ENDPOINT")
+                        .unwrap_or_else(|_| "http://trivy-api.security-scanning:8080".to_string());
+
+                    let config = CveScannerConfig {
+                        scanner_endpoint,
+                        namespaces,
+                        ..Default::default()
+                    };
+
+                    let pods = list_vulnerable_pods(&client, &config, min_severity).await?;
+
+                    if pods.is_empty() {
+                        println!("No vulnerable pods found (min severity: {}).", severity);
+                        return Ok(());
+                    }
+
+                    println!(
+                        "{:<40} {:<20} {:<50} {:>8} {:>6} {:>6} {:>6}",
+                        "NAMESPACE/POD", "IMAGE", "TAG", "CRITICAL", "HIGH", "MED", "LOW"
+                    );
+                    println!("{}", "-".repeat(140));
+
+                    for pod in &pods {
+                        let image_parts: Vec<&str> = pod.image.splitn(2, ':').collect();
+                        let (img, tag) = if image_parts.len() == 2 {
+                            (image_parts[0], image_parts[1])
+                        } else {
+                            (pod.image.as_str(), "latest")
+                        };
+
+                        let ns_pod = format!("{}/{}", pod.namespace, pod.pod_name);
+                        println!(
+                            "{:<40} {:<20} {:<50} {:>8} {:>6} {:>6} {:>6}",
+                            ns_pod,
+                            &img[img.len().saturating_sub(20)..],
+                            &tag[..tag.len().min(50)],
+                            pod.cve_count.critical,
+                            pod.cve_count.high,
+                            pod.cve_count.medium,
+                            pod.cve_count.low,
+                        );
+                    }
+
+                    println!("\nTotal: {} vulnerable pods", pods.len());
+                    Ok(())
+                }
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@
 pub mod backup;
 pub mod byzantine;
 pub mod carbon_aware;
+pub mod fork_detector;
 pub mod controller;
 pub mod crd;
 pub mod error;

--- a/src/webhook/mod.rs
+++ b/src/webhook/mod.rs
@@ -56,6 +56,7 @@
 //! ```
 
 pub mod mutation;
+pub mod org_validator;
 pub mod runtime;
 pub mod server;
 pub mod types;

--- a/src/webhook/org_validator.rs
+++ b/src/webhook/org_validator.rs
@@ -1,0 +1,328 @@
+//! Organizational Standards Validator
+//!
+//! Validates that all StellarNode resources meet organizational standards:
+//! - `resources.limits` and `resources.requests` are always present and non-empty.
+//! - Resource limits do not exceed per-node-type maximums.
+//! - Required labels (`project-id`, `owner`) are present.
+//!
+//! This runs as part of the built-in webhook validation pipeline, before any
+//! WASM plugins, so it cannot be bypassed.
+
+use crate::crd::{NodeType, StellarNode};
+
+/// A single validation failure with a clear, actionable message.
+#[derive(Debug, Clone)]
+pub struct OrgValidationError {
+    pub field: String,
+    pub message: String,
+    pub hint: String,
+}
+
+impl OrgValidationError {
+    fn new(
+        field: impl Into<String>,
+        message: impl Into<String>,
+        hint: impl Into<String>,
+    ) -> Self {
+        Self {
+            field: field.into(),
+            message: message.into(),
+            hint: hint.into(),
+        }
+    }
+}
+
+/// Maximum resource limits per node type (enforced by policy).
+struct MaxLimits {
+    cpu_millicores: u64,
+    memory_mib: u64,
+}
+
+fn max_limits_for(node_type: &NodeType) -> MaxLimits {
+    match node_type {
+        NodeType::Validator => MaxLimits {
+            cpu_millicores: 8_000,   // 8 cores
+            memory_mib: 16_384,      // 16 GiB
+        },
+        NodeType::Horizon => MaxLimits {
+            cpu_millicores: 8_000,
+            memory_mib: 16_384,
+        },
+        NodeType::SorobanRpc => MaxLimits {
+            cpu_millicores: 16_000,  // 16 cores — Soroban is more compute-intensive
+            memory_mib: 32_768,      // 32 GiB
+        },
+    }
+}
+
+/// Required labels that every StellarNode must carry.
+const REQUIRED_LABELS: &[(&str, &str)] = &[
+    (
+        "project-id",
+        "Add 'project-id: <your-project>' to metadata.labels for billing attribution.",
+    ),
+    (
+        "owner",
+        "Add 'owner: <team-or-user>' to metadata.labels to identify the responsible team.",
+    ),
+];
+
+/// Run all organizational standard checks against a StellarNode.
+/// Returns a list of errors; empty means the resource is compliant.
+pub fn validate_org_standards(node: &StellarNode) -> Vec<OrgValidationError> {
+    let mut errors = Vec::new();
+
+    validate_resource_presence(node, &mut errors);
+    validate_resource_limits(node, &mut errors);
+    validate_required_labels(node, &mut errors);
+
+    errors
+}
+
+/// Ensure resources.requests and resources.limits are non-empty / non-zero.
+fn validate_resource_presence(node: &StellarNode, errors: &mut Vec<OrgValidationError>) {
+    let r = &node.spec.resources;
+
+    if r.requests.cpu.trim().is_empty() || r.requests.cpu == "0" {
+        errors.push(OrgValidationError::new(
+            "spec.resources.requests.cpu",
+            "CPU request must be set to a non-zero value.",
+            "Set spec.resources.requests.cpu to a value like '500m' or '1'.",
+        ));
+    }
+
+    if r.requests.memory.trim().is_empty() || r.requests.memory == "0" {
+        errors.push(OrgValidationError::new(
+            "spec.resources.requests.memory",
+            "Memory request must be set to a non-zero value.",
+            "Set spec.resources.requests.memory to a value like '512Mi' or '1Gi'.",
+        ));
+    }
+
+    if r.limits.cpu.trim().is_empty() || r.limits.cpu == "0" {
+        errors.push(OrgValidationError::new(
+            "spec.resources.limits.cpu",
+            "CPU limit must be set to prevent noisy-neighbor issues.",
+            "Set spec.resources.limits.cpu to a value like '2' or '4000m'.",
+        ));
+    }
+
+    if r.limits.memory.trim().is_empty() || r.limits.memory == "0" {
+        errors.push(OrgValidationError::new(
+            "spec.resources.limits.memory",
+            "Memory limit must be set to prevent noisy-neighbor issues.",
+            "Set spec.resources.limits.memory to a value like '2Gi' or '4Gi'.",
+        ));
+    }
+}
+
+/// Ensure resource limits do not exceed per-node-type maximums.
+fn validate_resource_limits(node: &StellarNode, errors: &mut Vec<OrgValidationError>) {
+    let max = max_limits_for(&node.spec.node_type);
+    let limits = &node.spec.resources.limits;
+
+    if let Some(cpu_mc) = parse_cpu_millicores(&limits.cpu) {
+        if cpu_mc > max.cpu_millicores {
+            errors.push(OrgValidationError::new(
+                "spec.resources.limits.cpu",
+                format!(
+                    "CPU limit '{}' ({} millicores) exceeds the maximum allowed {} millicores for {:?} nodes.",
+                    limits.cpu, cpu_mc, max.cpu_millicores, node.spec.node_type
+                ),
+                format!(
+                    "Reduce spec.resources.limits.cpu to at most '{}m' for {:?} nodes.",
+                    max.cpu_millicores, node.spec.node_type
+                ),
+            ));
+        }
+    }
+
+    if let Some(mem_mib) = parse_memory_mib(&limits.memory) {
+        if mem_mib > max.memory_mib {
+            errors.push(OrgValidationError::new(
+                "spec.resources.limits.memory",
+                format!(
+                    "Memory limit '{}' ({} MiB) exceeds the maximum allowed {} MiB for {:?} nodes.",
+                    limits.memory, mem_mib, max.memory_mib, node.spec.node_type
+                ),
+                format!(
+                    "Reduce spec.resources.limits.memory to at most '{}Mi' for {:?} nodes.",
+                    max.memory_mib, node.spec.node_type
+                ),
+            ));
+        }
+    }
+}
+
+/// Ensure required labels are present on the StellarNode.
+fn validate_required_labels(node: &StellarNode, errors: &mut Vec<OrgValidationError>) {
+    let labels = node.metadata.labels.as_ref();
+
+    for (label_key, hint) in REQUIRED_LABELS {
+        let present = labels
+            .and_then(|l| l.get(*label_key))
+            .map(|v| !v.trim().is_empty())
+            .unwrap_or(false);
+
+        if !present {
+            errors.push(OrgValidationError::new(
+                format!("metadata.labels.{}", label_key),
+                format!("Required label '{}' is missing or empty.", label_key),
+                hint.to_string(),
+            ));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resource quantity parsers
+// ---------------------------------------------------------------------------
+
+/// Parse a Kubernetes CPU quantity string into millicores.
+/// Supports: "500m", "1", "2.5", "4000m"
+fn parse_cpu_millicores(s: &str) -> Option<u64> {
+    let s = s.trim();
+    if s.ends_with('m') {
+        s[..s.len() - 1].parse::<u64>().ok()
+    } else {
+        // Whole cores — multiply by 1000
+        s.parse::<f64>().ok().map(|v| (v * 1000.0) as u64)
+    }
+}
+
+/// Parse a Kubernetes memory quantity string into MiB.
+/// Supports: "512Mi", "1Gi", "2048M", "1073741824" (bytes)
+fn parse_memory_mib(s: &str) -> Option<u64> {
+    let s = s.trim();
+    if s.ends_with("Gi") {
+        s[..s.len() - 2]
+            .parse::<f64>()
+            .ok()
+            .map(|v| (v * 1024.0) as u64)
+    } else if s.ends_with("Mi") {
+        s[..s.len() - 2].parse::<u64>().ok()
+    } else if s.ends_with("G") {
+        s[..s.len() - 1]
+            .parse::<f64>()
+            .ok()
+            .map(|v| (v * 953.674) as u64) // 1 GB ≈ 953.674 MiB
+    } else if s.ends_with("M") {
+        s[..s.len() - 1]
+            .parse::<f64>()
+            .ok()
+            .map(|v| (v * 0.953674) as u64)
+    } else {
+        // Raw bytes
+        s.parse::<u64>().ok().map(|b| b / (1024 * 1024))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::{NodeType, StellarNode, StellarNodeSpec};
+    use crate::crd::types::{ResourceRequirements, ResourceSpec, StellarNetwork};
+
+    fn make_node(
+        node_type: NodeType,
+        cpu_req: &str,
+        mem_req: &str,
+        cpu_lim: &str,
+        mem_lim: &str,
+        labels: Option<std::collections::BTreeMap<String, String>>,
+    ) -> StellarNode {
+        let mut node = StellarNode::new(
+            "test",
+            StellarNodeSpec {
+                node_type,
+                network: StellarNetwork::Testnet,
+                version: "v21.0.0".to_string(),
+                resources: ResourceRequirements {
+                    requests: ResourceSpec {
+                        cpu: cpu_req.to_string(),
+                        memory: mem_req.to_string(),
+                    },
+                    limits: ResourceSpec {
+                        cpu: cpu_lim.to_string(),
+                        memory: mem_lim.to_string(),
+                    },
+                },
+                ..Default::default()
+            },
+        );
+        node.metadata.labels = labels;
+        node
+    }
+
+    fn good_labels() -> Option<std::collections::BTreeMap<String, String>> {
+        let mut m = std::collections::BTreeMap::new();
+        m.insert("project-id".to_string(), "stellar-prod".to_string());
+        m.insert("owner".to_string(), "platform-team".to_string());
+        Some(m)
+    }
+
+    #[test]
+    fn valid_node_passes() {
+        let node = make_node(
+            NodeType::Validator,
+            "500m", "1Gi", "2", "4Gi",
+            good_labels(),
+        );
+        let errors = validate_org_standards(&node);
+        assert!(errors.is_empty(), "Expected no errors, got: {:?}", errors);
+    }
+
+    #[test]
+    fn missing_labels_rejected() {
+        let node = make_node(NodeType::Validator, "500m", "1Gi", "2", "4Gi", None);
+        let errors = validate_org_standards(&node);
+        assert_eq!(errors.len(), 2);
+        assert!(errors.iter().any(|e| e.field.contains("project-id")));
+        assert!(errors.iter().any(|e| e.field.contains("owner")));
+    }
+
+    #[test]
+    fn empty_cpu_limit_rejected() {
+        let node = make_node(NodeType::Validator, "500m", "1Gi", "", "4Gi", good_labels());
+        let errors = validate_org_standards(&node);
+        assert!(errors.iter().any(|e| e.field.contains("limits.cpu")));
+    }
+
+    #[test]
+    fn cpu_limit_exceeds_max_rejected() {
+        // Validator max is 8000m (8 cores); 16 cores should fail.
+        let node = make_node(NodeType::Validator, "500m", "1Gi", "16", "4Gi", good_labels());
+        let errors = validate_org_standards(&node);
+        assert!(errors.iter().any(|e| e.field.contains("limits.cpu")));
+    }
+
+    #[test]
+    fn memory_limit_exceeds_max_rejected() {
+        // Validator max is 16384 MiB; 32Gi should fail.
+        let node = make_node(NodeType::Validator, "500m", "1Gi", "2", "32Gi", good_labels());
+        let errors = validate_org_standards(&node);
+        assert!(errors.iter().any(|e| e.field.contains("limits.memory")));
+    }
+
+    #[test]
+    fn soroban_allows_higher_limits() {
+        // SorobanRpc max is 16 cores / 32 GiB — 16 cores should pass.
+        let node = make_node(NodeType::SorobanRpc, "1", "2Gi", "16", "32Gi", good_labels());
+        let errors = validate_org_standards(&node);
+        assert!(errors.is_empty(), "Expected no errors, got: {:?}", errors);
+    }
+
+    #[test]
+    fn parse_cpu_millicores_works() {
+        assert_eq!(parse_cpu_millicores("500m"), Some(500));
+        assert_eq!(parse_cpu_millicores("2"), Some(2000));
+        assert_eq!(parse_cpu_millicores("0"), Some(0));
+    }
+
+    #[test]
+    fn parse_memory_mib_works() {
+        assert_eq!(parse_memory_mib("512Mi"), Some(512));
+        assert_eq!(parse_memory_mib("1Gi"), Some(1024));
+        assert_eq!(parse_memory_mib("2Gi"), Some(2048));
+    }
+}

--- a/src/webhook/server.rs
+++ b/src/webhook/server.rs
@@ -655,6 +655,23 @@ fn validate_spec_builtin(object: &serde_json::Value) -> Option<ServerValidationR
         });
     }
 
+    // Organizational standards: resource limits, required labels.
+    let org_errors = super::org_validator::validate_org_standards(&node);
+    if !org_errors.is_empty() {
+        let message = org_errors
+            .iter()
+            .map(|e| format!("[{}] {} — Hint: {}", e.field, e.message, e.hint))
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Some(ServerValidationResult {
+            allowed: false,
+            message: Some(message),
+            warnings: vec![],
+            plugin_results: vec![],
+            total_execution_time_ms: 0,
+        });
+    }
+
     let errors = node.spec.validate().err()?;
     // Format each error as: [spec.field] Message — Hint: how_to_fix
     let message = errors


### PR DESCRIPTION
This pr implement Stellar Fork Detection sidecar

- Add core fork detection logic in `detector.rs` that polls local Stellar Core and public anchor nodes, compares ledger hashes, and triggers alerts on divergence.
- Introduce Prometheus metrics in `metrics.rs` for monitoring fork detection status, including sync confidence, consecutive diverging ledgers, and total fork alerts.
- Create configuration types in `types.rs` for the fork detector, allowing customization of endpoints, polling intervals, and thresholds.
- Implement organizational standards validation in `org_validator.rs` to ensure StellarNode resources meet specified limits and required labels.
- Add tests for validation logic to ensure compliance with organizational standards.


Closes: #544
Closes: #543
Closes: #542
Closes: #541