### PR TITLE
docs: implement bug, feature, and support issue templates #595

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,14 +1,53 @@
 name: Bug Report
-description: Report a non-security bug in Stellar-K8s
+description: Report a reproducible bug in Stellar-K8s
+title: "[Bug]: "
 labels: ["bug", "triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        > **Security vulnerability?** Please use [GitHub Security Advisories](../../security/advisories/new) instead of this form.
+        > **Security vulnerability?** Use [GitHub Security Advisories](../../security/advisories/new) — do **not** open a public issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. Apply manifest ...
+        2. Run command ...
+        3. Observe error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / Logs
+      description: Paste relevant logs or attach screenshots. Logs are auto-formatted.
+      render: shell
+
+  - type: markdown
+    attributes:
+      value: "### Environment"
 
   - type: input
-    id: version
+    id: stellar-version
     attributes:
       label: Stellar-K8s Version
       placeholder: "e.g. 0.1.0"
@@ -23,33 +62,10 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    id: description
+  - type: input
+    id: os
     attributes:
-      label: Description
-      description: A clear description of the bug
+      label: Operating System
+      placeholder: "e.g. Ubuntu 22.04, macOS 14, Windows 11"
     validations:
       required: true
-
-  - type: textarea
-    id: reproduction
-    attributes:
-      label: Steps to Reproduce
-      placeholder: |
-        1. Apply manifest ...
-        2. Observe ...
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected Behavior
-    validations:
-      required: true
-
-  - type: textarea
-    id: logs
-    attributes:
-      label: Relevant Logs / Output
-      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,16 +1,10 @@
 blank_issues_enabled: false
 
 contact_links:
-  - name: "\U0001F512 Report a Security Vulnerability"
-    url: https://github.com/OtowoOrg/Stellar-K8s/security/advisories/new
-    about: >
-      Please use GitHub's private security advisory system to report vulnerabilities.
-      Do NOT open a public issue for security reports.
+  - name: 💬 Ask a Question / Get Support
+    url: https://github.com/Dami24-hub/Stellar-K8s/discussions
+    about: Use GitHub Discussions for questions, troubleshooting, and general help.
 
-  - name: "\U0001F41B Bug Report"
-    url: https://github.com/OtowoOrg/Stellar-K8s/issues/new?template=bug_report.yml
-    about: Report a non-security bug
-
-  - name: "\U0001F4AC Discussions"
-    url: https://github.com/OtowoOrg/Stellar-K8s/discussions
-    about: Ask questions or discuss ideas
+  - name: 🔒 Report a Security Vulnerability
+    url: https://github.com/Dami24-hub/Stellar-K8s/security/advisories/new
+    about: Please use GitHub's private security advisory system. Do NOT open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: Propose a new feature or enhancement for Stellar-K8s
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? Why is it needed?
+      placeholder: "I'm trying to do X but currently there's no way to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature you'd like and how it should work.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches did you consider, and why did you rule them out?

--- a/.github/ISSUE_TEMPLATE/support.yml
+++ b/.github/ISSUE_TEMPLATE/support.yml
@@ -1,0 +1,18 @@
+name: Support Question
+description: Need help? Please use GitHub Discussions to keep the issue tracker focused on bugs and features.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 👋 Looking for help?
+
+        The issue tracker is reserved for **bugs** and **feature requests**.
+        For questions, troubleshooting, and general discussion please use one of the channels below:
+
+        | Channel | Link |
+        |---------|------|
+        | 💬 GitHub Discussions | [Start a discussion](https://github.com/Dami24-hub/Stellar-K8s/discussions) |
+        | 📖 Documentation | [Read the docs](https://github.com/Dami24-hub/Stellar-K8s/tree/main/docs) |
+        | 🔒 Security issue? | [Report privately](https://github.com/Dami24-hub/Stellar-K8s/security/advisories/new) |
+
+        Please close this issue and open a discussion instead. Thank you! 🙏


### PR DESCRIPTION
Description:
This PR introduces a structured community support framework by implementing GitHub Issue Templates. These templates ensure that all incoming bugs and features include the necessary environment context and reproduction steps, reducing the "back-and-forth" between maintainers and contributors.

Changes:

Bug Reports: Added a comprehensive template requiring Environment Info (K8s/Stellar versions) and Steps to Reproduce.

Feature Requests: Added a template focused on the "Why" and "How" of new functionality.

Support Redirection: Implemented a support template that guides users to the Discussions tab, keeping the Issue tracker focused on actionable development tasks.

Configuration: Added config.yml to prevent blank issue creation and enforce template usage.

Technical Highlights:

Data Quality: Standardizes input formats, allowing for faster triage and automated labeling in the future.

User Experience: Provides clear prompts for contributors, making it easier for them to provide helpful information on their first attempt.

Checklist:

[x] Branch community/issue-templates-595 created and pushed.

[x] .github/ISSUE_TEMPLATE/ directory populated with YAML files.

[x] Environment Info and Steps to Reproduce sections included.

[x] Discussion link added for support questions.

[x] Linked to Issue #595.
closes #595