### PR TITLE
[703] Optimize Heavy Validation Workflows (Chaos, Soak, Operator Boot)

### DIFF
--- a/.github/CI_COMMANDS.md
+++ b/.github/CI_COMMANDS.md
@@ -47,7 +47,7 @@ the critical path by ~35–40% compared to the previous sequential layout.
 
 ---
 
-## Heavy Validation Workflows (#666)
+## Heavy Validation Workflows (#703)
 
 ### `chaos-tests.yml`
 - **Extracted** cluster provisioning into `setup-kind-cluster` composite action.

--- a/.github/workflows/chaos-tests.yml
+++ b/.github/workflows/chaos-tests.yml
@@ -1,0 +1,368 @@
+# .github/workflows/chaos-tests.yml
+#
+# Chaos Engineering CI for Stellar-K8s.
+#
+# Cluster provisioning is centralised in .github/actions/setup-kind-cluster.
+# Log/artifact gathering is centralised in .github/actions/collect-e2e-logs.
+#
+# The operator binary and Docker image are built ONCE in the `build` job and
+# shared as artifacts so the two parallel experiment groups never rebuild.
+#
+# Triggers:
+#   - Manual (workflow_dispatch) — any branch
+#   - Nightly schedule (02:00 UTC)
+
+name: Chaos Engineering Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_experiment:
+        description: "Skip a specific experiment (01-05). Leave blank to run all."
+        required: false
+        default: ""
+  schedule:
+    - cron: "0 2 * * *"
+
+env:
+  CARGO_TERM_COLOR: always
+  CLUSTER_NAME: stellar-chaos
+  OPERATOR_NAMESPACE: stellar-system
+  CHAOS_NAMESPACE: chaos-testing
+  CHAOS_MESH_VERSION: "2.6.3"
+  IMAGE_TAG: chaos-test
+
+jobs:
+  # ── Build operator binary & Docker image once ────────────────────────────────
+  build:
+    name: Build Operator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-key: "chaos-build"
+
+      - name: Build operator binary
+        run: cargo build --release --locked --bin stellar-operator
+
+      - name: Build Docker image
+        run: docker build -t stellar-operator:${{ env.IMAGE_TAG }} .
+
+      - name: Save Docker image as artifact
+        run: |
+          docker save stellar-operator:${{ env.IMAGE_TAG }} \
+            | gzip > stellar-operator-chaos.tar.gz
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: chaos-operator-artifacts
+          path: stellar-operator-chaos.tar.gz
+          retention-days: 1
+
+  # ── Experiments 01 & 02 (pod-kill + network partition) ───────────────────────
+  # Runs in parallel with chaos-latency-disk — uses a separate cluster name
+  # so both jobs can run simultaneously on the same runner pool.
+  chaos-kill-network:
+    name: "Chaos: Pod Kill & Network Partition"
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download operator artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: chaos-operator-artifacts
+
+      - name: Load Docker image
+        run: |
+          gunzip stellar-operator-chaos.tar.gz
+          docker load < stellar-operator-chaos.tar
+
+      - name: Setup kind cluster
+        uses: ./.github/actions/setup-kind-cluster
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}-kn
+          image-tag: ${{ env.IMAGE_TAG }}
+          operator-namespace: ${{ env.OPERATOR_NAMESPACE }}
+          worker-nodes: "2"
+          skip-docker-build: "true"
+
+      - name: Create test StellarNode
+        run: |
+          kubectl apply -f - <<EOF
+          apiVersion: stellar.org/v1alpha1
+          kind: StellarNode
+          metadata:
+            name: chaos-test-horizon
+            namespace: ${{ env.OPERATOR_NAMESPACE }}
+          spec:
+            nodeType: Horizon
+            network: Testnet
+            version: "v21.0.0"
+            replicas: 1
+            horizonConfig:
+              databaseSecretRef: horizon-db-secret
+              enableIngest: false
+              stellarCoreUrl: "http://localhost:11626"
+              ingestWorkers: 1
+              enableExperimentalIngestion: false
+              autoMigration: false
+          EOF
+          sleep 30
+
+      - name: Install Chaos Mesh
+        run: |
+          helm repo add chaos-mesh https://charts.chaos-mesh.org
+          helm repo update
+          kubectl create namespace chaos-mesh
+          helm install chaos-mesh chaos-mesh/chaos-mesh \
+            --namespace chaos-mesh \
+            --version ${{ env.CHAOS_MESH_VERSION }} \
+            --set chaosDaemon.runtime=containerd \
+            --set chaosDaemon.socketPath=/run/containerd/containerd.sock \
+            --wait --timeout=5m
+          kubectl create namespace ${{ env.CHAOS_NAMESPACE }} \
+            --dry-run=client -o yaml | kubectl apply -f -
+          kubectl apply -f - <<EOF
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: chaos-mesh-stellar-system
+            namespace: ${{ env.OPERATOR_NAMESPACE }}
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: chaos-mesh-chaos-controller-manager-target-namespace
+          subjects:
+            - kind: ServiceAccount
+              name: chaos-controller-manager
+              namespace: chaos-mesh
+          EOF
+
+      - name: "Experiment 01: Operator Pod Kill"
+        if: github.event.inputs.skip_experiment != '01'
+        run: |
+          kubectl apply -f tests/chaos/01-operator-pod-kill.yaml \
+            --namespace=${{ env.CHAOS_NAMESPACE }}
+          sleep 40
+          kubectl delete -f tests/chaos/01-operator-pod-kill.yaml \
+            --namespace=${{ env.CHAOS_NAMESPACE }} --ignore-not-found
+          kubectl wait pod \
+            --for=condition=Ready \
+            --selector=app=stellar-operator \
+            --namespace=${{ env.OPERATOR_NAMESPACE }} \
+            --timeout=120s
+          kubectl logs --selector=app=stellar-operator \
+            --namespace=${{ env.OPERATOR_NAMESPACE }} --tail=300 \
+            > /tmp/exp01-logs.txt || true
+          echo "Experiment 01 PASSED"
+
+      - name: "Experiment 02: Network Partition"
+        if: github.event.inputs.skip_experiment != '02'
+        run: |
+          kubectl apply -f tests/chaos/02-network-partition.yaml \
+            --namespace=${{ env.CHAOS_NAMESPACE }}
+          sleep 70
+          kubectl delete -f tests/chaos/02-network-partition.yaml \
+            --namespace=${{ env.CHAOS_NAMESPACE }} --ignore-not-found
+          kubectl wait pod \
+            --for=condition=Ready \
+            --selector=app=stellar-operator \
+            --namespace=${{ env.OPERATOR_NAMESPACE }} \
+            --timeout=120s
+          kubectl logs --selector=app=stellar-operator \
+            --namespace=${{ env.OPERATOR_NAMESPACE }} --tail=300 \
+            > /tmp/exp02-logs.txt || true
+          echo "Experiment 02 PASSED"
+
+      - name: Collect logs
+        if: always()
+        uses: ./.github/actions/collect-e2e-logs
+        with:
+          operator-namespace: ${{ env.OPERATOR_NAMESPACE }}
+          artifact-name: chaos-kill-network-logs-${{ github.run_id }}
+          extra-namespaces: ${{ env.CHAOS_NAMESPACE }}
+
+  # ── Experiments 03, 04 & 05 (latency, peer-partition, disk) ─────────────────
+  chaos-latency-disk:
+    name: "Chaos: Latency, Peer Partition & Disk Fill"
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download operator artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: chaos-operator-artifacts
+
+      - name: Load Docker image
+        run: |
+          gunzip stellar-operator-chaos.tar.gz
+          docker load < stellar-operator-chaos.tar
+
+      - name: Setup kind cluster
+        uses: ./.github/actions/setup-kind-cluster
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}-ld
+          image-tag: ${{ env.IMAGE_TAG }}
+          operator-namespace: ${{ env.OPERATOR_NAMESPACE }}
+          worker-nodes: "2"
+          skip-docker-build: "true"
+
+      - name: Create test StellarNode
+        run: |
+          kubectl apply -f - <<EOF
+          apiVersion: stellar.org/v1alpha1
+          kind: StellarNode
+          metadata:
+            name: chaos-test-horizon
+            namespace: ${{ env.OPERATOR_NAMESPACE }}
+          spec:
+            nodeType: Horizon
+            network: Testnet
+            version: "v21.0.0"
+            replicas: 1
+            horizonConfig:
+              databaseSecretRef: horizon-db-secret
+              enableIngest: false
+              stellarCoreUrl: "http://localhost:11626"
+              ingestWorkers: 1
+              enableExperimentalIngestion: false
+              autoMigration: false
+          EOF
+          sleep 30
+
+      - name: Install Chaos Mesh
+        run: |
+          helm repo add chaos-mesh https://charts.chaos-mesh.org
+          helm repo update
+          kubectl create namespace chaos-mesh
+          helm install chaos-mesh chaos-mesh/chaos-mesh \
+            --namespace chaos-mesh \
+            --version ${{ env.CHAOS_MESH_VERSION }} \
+            --set chaosDaemon.runtime=containerd \
+            --set chaosDaemon.socketPath=/run/containerd/containerd.sock \
+            --wait --timeout=5m
+          kubectl create namespace ${{ env.CHAOS_NAMESPACE }} \
+            --dry-run=client -o yaml | kubectl apply -f -
+          kubectl apply -f - <<EOF
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: chaos-mesh-stellar-system
+            namespace: ${{ env.OPERATOR_NAMESPACE }}
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: chaos-mesh-chaos-controller-manager-target-namespace
+          subjects:
+            - kind: ServiceAccount
+              name: chaos-controller-manager
+              namespace: chaos-mesh
+          EOF
+
+      - name: "Experiment 03: API High Latency"
+        if: github.event.inputs.skip_experiment != '03'
+        run: |
+          kubectl apply -f tests/chaos/03-api-latency.yaml \
+            --namespace=${{ env.CHAOS_NAMESPACE }}
+          sleep 130
+          kubectl delete -f tests/chaos/03-api-latency.yaml \
+            --namespace=${{ env.CHAOS_NAMESPACE }} --ignore-not-found
+          kubectl wait pod \
+            --for=condition=Ready \
+            --selector=app=stellar-operator \
+            --namespace=${{ env.OPERATOR_NAMESPACE }} \
+            --timeout=180s
+          kubectl logs --selector=app=stellar-operator \
+            --namespace=${{ env.OPERATOR_NAMESPACE }} --tail=300 \
+            > /tmp/exp03-logs.txt || true
+          echo "Experiment 03 PASSED"
+
+      - name: "Experiment 04: Validator Peer Partition"
+        if: github.event.inputs.skip_experiment != '04'
+        run: |
+          kubectl apply -f tests/chaos/04-validator-peer-partition.yaml \
+            --namespace=${{ env.CHAOS_NAMESPACE }}
+          sleep 100
+          kubectl delete -f tests/chaos/04-validator-peer-partition.yaml \
+            --namespace=${{ env.CHAOS_NAMESPACE }} --ignore-not-found
+          kubectl wait pod \
+            --for=condition=Ready \
+            --selector=app=stellar-operator \
+            --namespace=${{ env.OPERATOR_NAMESPACE }} \
+            --timeout=120s
+          kubectl logs --selector=app=stellar-operator \
+            --namespace=${{ env.OPERATOR_NAMESPACE }} --tail=300 \
+            > /tmp/exp04-logs.txt || true
+          echo "Experiment 04 PASSED"
+
+      - name: "Experiment 05: Operator Disk Fill"
+        if: github.event.inputs.skip_experiment != '05'
+        run: |
+          kubectl apply -f tests/chaos/05-disk-fill.yaml \
+            --namespace=${{ env.CHAOS_NAMESPACE }}
+          sleep 50
+          kubectl delete -f tests/chaos/05-disk-fill.yaml \
+            --namespace=${{ env.CHAOS_NAMESPACE }} --ignore-not-found
+          kubectl wait pod \
+            --for=condition=Ready \
+            --selector=app=stellar-operator \
+            --namespace=${{ env.OPERATOR_NAMESPACE }} \
+            --timeout=120s
+          kubectl logs --selector=app=stellar-operator \
+            --namespace=${{ env.OPERATOR_NAMESPACE }} --tail=300 \
+            > /tmp/exp05-logs.txt || true
+          echo "Experiment 05 PASSED"
+
+      - name: Collect logs
+        if: always()
+        uses: ./.github/actions/collect-e2e-logs
+        with:
+          operator-namespace: ${{ env.OPERATOR_NAMESPACE }}
+          artifact-name: chaos-latency-disk-logs-${{ github.run_id }}
+          extra-namespaces: ${{ env.CHAOS_NAMESPACE }}
+
+  # ── Generate resilience report after both parallel jobs finish ───────────────
+  report:
+    name: Generate Resilience Report
+    runs-on: ubuntu-latest
+    needs: [chaos-kill-network, chaos-latency-disk]
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate resilience report
+        run: |
+          chmod +x tests/chaos/generate-report.sh
+          ./tests/chaos/generate-report.sh
+
+      - name: Upload resilience report
+        uses: actions/upload-artifact@v4
+        with:
+          name: chaos-resilience-report-${{ github.run_id }}
+          path: tests/chaos/results/*/resilience-report.md
+          retention-days: 30
+
+      - name: Write job summary
+        run: |
+          KN="${{ needs.chaos-kill-network.result }}"
+          LD="${{ needs.chaos-latency-disk.result }}"
+          {
+            echo "## 🔥 Chaos Engineering Test Results"
+            echo ""
+            echo "| Group | Experiments | Status |"
+            echo "|-------|-------------|--------|"
+            echo "| Kill & Network | 01 Pod Kill, 02 Network Partition | ${KN} |"
+            echo "| Latency & Disk | 03 API Latency, 04 Peer Partition, 05 Disk Fill | ${LD} |"
+            echo ""
+            echo "**Commit:** ${{ github.sha }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -1,0 +1,101 @@
+# .github/workflows/soak-test.yml
+#
+# 1-hour memory soak test for the stellar-operator.
+#
+# Cluster provisioning uses the shared .github/actions/setup-kind-cluster
+# composite action. Logs are gathered via .github/actions/collect-e2e-logs.
+#
+# Triggers:
+#   - Manual (workflow_dispatch)
+#   - Weekly schedule (Saturday 02:00 UTC)
+
+name: Memory Soak Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      soak_duration:
+        description: "Soak duration in seconds (default: 3600)"
+        required: false
+        default: "3600"
+      threshold_kb:
+        description: "Max allowed RSS growth in kB (default: 5120 = 5 MB)"
+        required: false
+        default: "5120"
+      cleanup_timeout_seconds:
+        description: "Cleanup wait timeout in seconds (default: 120)"
+        required: false
+        default: "120"
+  schedule:
+    - cron: "0 2 * * 6"
+
+env:
+  CARGO_TERM_COLOR: always
+  CLUSTER_NAME: stellar-soak
+  OPERATOR_NAMESPACE: stellar-system
+  IMAGE_TAG: soak-test
+
+jobs:
+  soak-test:
+    name: Operator Memory Soak (1 h)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Build binary ──────────────────────────────────────────────────────
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-key: "soak-build"
+
+      - name: Build operator binary
+        run: cargo build --release --locked --bin stellar-operator
+
+      # ── Build Docker image ────────────────────────────────────────────────
+      - name: Build Docker image
+        run: docker build -t stellar-operator:${{ env.IMAGE_TAG }} .
+
+      # ── Provision cluster (shared composite action, image already built) ──
+      - name: Setup kind cluster
+        uses: ./.github/actions/setup-kind-cluster
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          image-tag: ${{ env.IMAGE_TAG }}
+          operator-namespace: ${{ env.OPERATOR_NAMESPACE }}
+          worker-nodes: "1"
+          operator-cpu-request: "200m"
+          operator-memory-request: "128Mi"
+          operator-cpu-limit: "500m"
+          operator-memory-limit: "512Mi"
+          skip-docker-build: "true"
+
+      # ── Run soak test ─────────────────────────────────────────────────────
+      - name: Run soak test
+        env:
+          OPERATOR_NAMESPACE: ${{ env.OPERATOR_NAMESPACE }}
+          SOAK_DURATION: ${{ github.event.inputs.soak_duration || '3600' }}
+          THRESHOLD_KB: ${{ github.event.inputs.threshold_kb || '5120' }}
+          CLEANUP_TIMEOUT_SECONDS: ${{ github.event.inputs.cleanup_timeout_seconds || '120' }}
+          TEST_NAMESPACE: soak-test
+          RESULTS_FILE: /tmp/soak-memory.log
+        run: bash scripts/soak-test.sh
+
+      # ── Upload results ────────────────────────────────────────────────────
+      - name: Upload memory samples
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: soak-memory-samples-${{ github.run_id }}
+          path: /tmp/soak-memory.log
+          retention-days: 30
+
+      # ── Consolidated log collection ───────────────────────────────────────
+      - name: Collect logs on failure
+        if: failure()
+        uses: ./.github/actions/collect-e2e-logs
+        with:
+          operator-namespace: ${{ env.OPERATOR_NAMESPACE }}
+          artifact-name: soak-debug-logs-${{ github.run_id }}
+          extra-namespaces: "soak-test"

--- a/.github/workflows/verify-operator-boot.yml
+++ b/.github/workflows/verify-operator-boot.yml
@@ -1,0 +1,157 @@
+name: "Verify Operator Boot"
+
+# Verifies that the operator binary builds and connects to a live kind cluster.
+# Acceptance criteria:
+#   1. cargo build --release succeeds with zero errors
+#   2. ./target/release/stellar-operator run starts against a kind cluster
+#   3. Log line "Connected to Kubernetes cluster" appears
+#
+# Uses shared composite actions for Rust setup and log collection.
+
+on:
+  push:
+    branches: [main, "fix/issue-146-*"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: verify-boot-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CLUSTER_NAME: stellar-verify
+  OPERATOR_NAMESPACE: stellar-system
+
+jobs:
+  verify-operator-boot:
+    name: Verify Operator Boot & Cluster Connection
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Scope check: skip on PRs that don't touch operator code ──────────
+      - name: Decide whether boot verification should run
+        id: scope
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" || true)
+          echo "$CHANGED"
+          if echo "$CHANGED" | grep -Eq '^(src/|config/crd/|Cargo\.toml|Cargo\.lock|build\.rs|Makefile)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Build (AC #1) ─────────────────────────────────────────────────────
+      - name: Setup Rust
+        if: steps.scope.outputs.run == 'true'
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-key: "verify-boot"
+
+      - name: Build release binary
+        if: steps.scope.outputs.run == 'true'
+        run: cargo build --release --locked --bin stellar-operator
+
+      - name: Confirm binary exists
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          ls -lh target/release/stellar-operator
+          echo "✅ cargo build --release succeeded"
+
+      # ── Create kind cluster (AC #2) ───────────────────────────────────────
+      - name: Install kind
+        if: steps.scope.outputs.run == 'true'
+        uses: helm/kind-action@v1.14.0
+        with:
+          install_only: true
+
+      - name: Create kind cluster
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          kind create cluster --name ${{ env.CLUSTER_NAME }} --wait 60s
+          kubectl cluster-info --context kind-${{ env.CLUSTER_NAME }}
+          echo "✅ kind cluster '${{ env.CLUSTER_NAME }}' is ready"
+
+      # ── Install CRD ───────────────────────────────────────────────────────
+      - name: Install StellarNode CRD
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          kubectl apply -f config/crd/stellarnode-crd.yaml
+          kubectl wait --for=condition=established --timeout=30s \
+            crd/stellarnodes.stellar.org || true
+
+      # ── Run operator and verify log line (AC #2 + AC #3) ─────────────────
+      - name: Run operator and verify cluster connection
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          ./target/release/stellar-operator run \
+            --namespace ${{ env.OPERATOR_NAMESPACE }} \
+            > /tmp/operator.log 2>&1 &
+          OPERATOR_PID=$!
+          echo "Operator PID: $OPERATOR_PID"
+
+          TIMEOUT=60
+          ELAPSED=0
+          FOUND=false
+          while [[ $ELAPSED -lt $TIMEOUT ]]; do
+            if grep -q "Connected to Kubernetes cluster" /tmp/operator.log 2>/dev/null; then
+              FOUND=true
+              break
+            fi
+            sleep 1
+            ELAPSED=$((ELAPSED + 1))
+          done
+
+          echo "--- Operator log ---"
+          cat /tmp/operator.log || true
+          echo "--------------------"
+
+          kill "$OPERATOR_PID" 2>/dev/null || true
+
+          if [[ "$FOUND" == "true" ]]; then
+            echo "✅ Log line 'Connected to Kubernetes cluster' confirmed"
+          else
+            echo "❌ Log line 'Connected to Kubernetes cluster' NOT found within ${TIMEOUT}s"
+            exit 1
+          fi
+
+      # ── Runtime error check ───────────────────────────────────────────────
+      - name: Report runtime errors
+        if: always() && steps.scope.outputs.run == 'true'
+        run: |
+          echo "--- Runtime error check ---"
+          if grep -iE "error|panic|missing env" /tmp/operator.log 2>/dev/null; then
+            echo "⚠️  Errors found in operator log (see above)"
+          else
+            echo "✅ No runtime errors detected"
+          fi
+
+      # ── Upload log artifact ───────────────────────────────────────────────
+      - name: Upload operator log
+        if: always() && steps.scope.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: operator-boot-log-${{ github.run_id }}
+          path: /tmp/operator.log
+          retention-days: 7
+
+      # ── Cleanup ───────────────────────────────────────────────────────────
+      - name: Delete kind cluster
+        if: always() && steps.scope.outputs.run == 'true'
+        run: kind delete cluster --name ${{ env.CLUSTER_NAME }} || true
+
+      - name: Skip message
+        if: steps.scope.outputs.run != 'true'
+        run: echo "Skipping verify-operator-boot — no operator/runtime files changed."


### PR DESCRIPTION
## Summary
- Restored `chaos-tests.yml`, `soak-test.yml`, and `verify-operator-boot.yml` using shared `setup-kind-cluster` and `collect-e2e-logs` composite actions
- Chaos experiments 01–02 and 03–05 run in parallel jobs with a shared build artifact (no duplicate Rust compilation)
- Increased operator boot verification timeout to 60s to reduce flakiness; consolidated log/artifact gathering across all e2e tests

Closes #703

## Test plan
- [x] `make test` passes locally
- [ ] Chaos, soak, and verify-operator-boot workflows pass on CI