### PR TITLE
feat(ingress): add configurable NGINX rate limiting to ingress contro…

### DIFF
--- a/examples/ingress-example.yaml
+++ b/examples/ingress-example.yaml
@@ -63,8 +63,15 @@ spec:
     # Additional annotations for ingress controller
     annotations:
       cert-manager.io/issue-temporary-certificate: "true"
-      nginx.ingress.kubernetes.io/rate-limit: "1000"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
+
+    # Configurable rate limiting for public-facing Horizon nodes (NGINX ingress)
+    rateLimit:
+      requestsPerSecond: 50      # max 50 req/s per client IP
+      requestsPerMinute: 1000    # max 1000 req/min per client IP
+      connections: 20            # max 20 concurrent connections per client IP
+      burstMultiplier: 5         # allow bursts up to 5x the per-second limit
+      whitelistCidrs: "10.0.0.0/8,192.168.0.0/16"  # internal CIDRs exempt from limiting
 
 ---
 # Example: Soroban RPC node with Ingress and mTLS setup

--- a/src/controller/resources.rs
+++ b/src/controller/resources.rs
@@ -1588,6 +1588,39 @@ fn build_ingress(node: &StellarNode, config: &IngressConfig) -> Ingress {
         }
     }
 
+    if let Some(rl) = &config.rate_limit {
+        if let Some(rps) = rl.requests_per_second {
+            annotations.insert(
+                "nginx.ingress.kubernetes.io/limit-rps".to_string(),
+                rps.to_string(),
+            );
+        }
+        if let Some(rpm) = rl.requests_per_minute {
+            annotations.insert(
+                "nginx.ingress.kubernetes.io/limit-rpm".to_string(),
+                rpm.to_string(),
+            );
+        }
+        if let Some(conns) = rl.connections {
+            annotations.insert(
+                "nginx.ingress.kubernetes.io/limit-connections".to_string(),
+                conns.to_string(),
+            );
+        }
+        if let Some(burst) = rl.burst_multiplier {
+            annotations.insert(
+                "nginx.ingress.kubernetes.io/limit-burst-multiplier".to_string(),
+                burst.to_string(),
+            );
+        }
+        if let Some(whitelist) = &rl.whitelist_cidrs {
+            annotations.insert(
+                "nginx.ingress.kubernetes.io/limit-whitelist".to_string(),
+                whitelist.clone(),
+            );
+        }
+    }
+
     let rules: Vec<IngressRule> = config
         .hosts
         .iter()

--- a/src/crd/stellar_node.rs
+++ b/src/crd/stellar_node.rs
@@ -910,6 +910,37 @@ fn validate_ingress(ingress: &IngressConfig, errors: &mut Vec<SpecValidationErro
             }
         }
     }
+
+    if let Some(rl) = &ingress.rate_limit {
+        if rl.requests_per_second == Some(0) {
+            errors.push(SpecValidationError::new(
+                "spec.ingress.rateLimit.requestsPerSecond",
+                "ingress.rateLimit.requestsPerSecond must be greater than 0",
+                "Set spec.ingress.rateLimit.requestsPerSecond to a positive integer.",
+            ));
+        }
+        if rl.requests_per_minute == Some(0) {
+            errors.push(SpecValidationError::new(
+                "spec.ingress.rateLimit.requestsPerMinute",
+                "ingress.rateLimit.requestsPerMinute must be greater than 0",
+                "Set spec.ingress.rateLimit.requestsPerMinute to a positive integer.",
+            ));
+        }
+        if rl.connections == Some(0) {
+            errors.push(SpecValidationError::new(
+                "spec.ingress.rateLimit.connections",
+                "ingress.rateLimit.connections must be greater than 0",
+                "Set spec.ingress.rateLimit.connections to a positive integer.",
+            ));
+        }
+        if rl.burst_multiplier == Some(0) {
+            errors.push(SpecValidationError::new(
+                "spec.ingress.rateLimit.burstMultiplier",
+                "ingress.rateLimit.burstMultiplier must be greater than 0",
+                "Set spec.ingress.rateLimit.burstMultiplier to a positive integer.",
+            ));
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/src/crd/types.rs
+++ b/src/crd/types.rs
@@ -949,6 +949,35 @@ pub struct SecretKeyRef {
     pub key: String,
 }
 
+/// NGINX ingress rate-limiting configuration.
+///
+/// Maps directly to the `nginx.ingress.kubernetes.io/limit-*` annotation family.
+/// All fields are optional; omitting a field leaves the corresponding annotation unset.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RateLimitConfig {
+    /// Maximum number of requests per second per client IP.
+    /// Sets `nginx.ingress.kubernetes.io/limit-rps`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requests_per_second: Option<u32>,
+    /// Maximum number of requests per minute per client IP.
+    /// Sets `nginx.ingress.kubernetes.io/limit-rpm`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requests_per_minute: Option<u32>,
+    /// Maximum number of concurrent connections per client IP.
+    /// Sets `nginx.ingress.kubernetes.io/limit-connections`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connections: Option<u32>,
+    /// Burst multiplier applied on top of the per-second limit (NGINX `burst` parameter).
+    /// Sets `nginx.ingress.kubernetes.io/limit-burst-multiplier`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub burst_multiplier: Option<u32>,
+    /// Comma-separated list of CIDRs that are exempt from rate limiting.
+    /// Sets `nginx.ingress.kubernetes.io/limit-whitelist`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub whitelist_cidrs: Option<String>,
+}
+
 /// Ingress configuration
 #[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -967,6 +996,9 @@ pub struct IngressConfig {
     /// ExternalDNS configuration for automated record management
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_dns: Option<ExternalDNSConfig>,
+    /// NGINX rate-limiting configuration for public-facing Horizon/SorobanRpc nodes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limit: Option<RateLimitConfig>,
 }
 
 /// Ingress host entry


### PR DESCRIPTION
…ller

Implements #713 - configurable rate limiting for public-facing Horizon and SorobanRpc nodes via the NGINX ingress controller annotation family.

Changes:
- Add RateLimitConfig struct to CRD types with fields for requestsPerSecond, requestsPerMinute, connections, burstMultiplier, and whitelistCidrs
- Add rate_limit field (optional) to IngressConfig CRD struct
- Extend build_ingress() in resources.rs to emit nginx.ingress.kubernetes.io/ limit-* annotations when rate_limit is configured
- Extend validate_ingress() to reject zero values for numeric rate limit fields
- Update ingress-example.yaml to demonstrate the new rateLimit config block

Annotations applied:
  nginx.ingress.kubernetes.io/limit-rps nginx.ingress.kubernetes.io/limit-rpm nginx.ingress.kubernetes.io/limit-connections nginx.ingress.kubernetes.io/limit-burst-multiplier nginx.ingress.kubernetes.io/limit-whitelist

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (`cargo clippy --all-targets --all-features -- -D warnings` passes)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes (`cargo test`)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have signed-off my commits with the Developer Certificate of Origin (DCO) using `git commit -s`
closes #713