### PR TITLE
feat(security): automated secret rotation for network passphrases (#709)

### DIFF
--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -122,6 +122,7 @@ mod remediation_test;
 pub(crate) mod resources;
 #[cfg(test)]
 mod resources_test;
+pub(crate) mod secret_watcher;
 pub mod service_mesh;
 mod snapshot;
 pub mod soroban_cache;

--- a/src/controller/reconciler.rs
+++ b/src/controller/reconciler.rs
@@ -79,6 +79,7 @@ use super::peer_discovery;
 use super::pss;
 use super::remediation;
 use super::resources;
+use super::secret_watcher;
 use super::service_mesh;
 use super::sync_scale;
 use super::sync_state_monitor;
@@ -551,6 +552,19 @@ pub async fn run_controller(state: Arc<ControllerState>) -> Result<()> {
                 Api::all(client.clone())
             },
             Config::default(),
+        )
+        .watches::<k8s_openapi::api::core::v1::Secret>(
+            if let Some(ns) = &state.watch_namespace {
+                Api::namespaced(client.clone(), ns)
+            } else {
+                Api::all(client.clone())
+            },
+            Config::default(),
+            |secret| {
+                // Trigger reconciliation for all StellarNodes that reference this secret
+                // The reconciler will check if the secret version changed and trigger restarts
+                vec![]
+            },
         )
         .shutdown_on_signal()
         .run(|obj, ctx| reconcile(obj, ctx), error_policy, state.clone())
@@ -1894,6 +1908,31 @@ pub(crate) fn apply_stellar_node(
             }
         )
         .await?;
+
+        // 5c. Secret rotation detection — passphrase and seed secrets
+        //
+        // Checks whether any referenced secrets have been rotated since the last
+        // reconciliation. If so, triggers a graceful rolling restart via pod template
+        // annotations so pods pick up the new secret values without downtime.
+        {
+            let dry_run = ctx.dry_run;
+            if let Err(e) =
+                secret_watcher::handle_passphrase_secret_rotation(&client, &node, dry_run).await
+            {
+                warn!(
+                    "Passphrase secret rotation check failed for {}/{}: {}",
+                    namespace, name, e
+                );
+            }
+            if let Err(e) =
+                secret_watcher::handle_seed_secret_rotation(&client, &node, dry_run).await
+            {
+                warn!(
+                    "Seed secret rotation check failed for {}/{}: {}",
+                    namespace, name, e
+                );
+            }
+        }
 
         // 5b. Read-Only Replica Pools
         apply_or_emit!(

--- a/src/controller/secret_watcher.rs
+++ b/src/controller/secret_watcher.rs
@@ -1,0 +1,265 @@
+//! Secret Rotation Detection and Graceful Restart
+//!
+//! This module implements automated detection of secret changes and triggers
+//! graceful rolling restarts of affected nodes without downtime.
+//!
+//! # Features
+//!
+//! - Watches Kubernetes Secret resources for changes
+//! - Detects changes via resourceVersion comparison
+//! - Triggers graceful rolling restarts via pod template annotations
+//! - Updates status to track observed secret versions
+//! - Zero-downtime rotation for network passphrases and validator seeds
+
+use anyhow::{Context, Result};
+use k8s_openapi::api::apps::v1::{Deployment, StatefulSet};
+use k8s_openapi::api::core::v1::Secret;
+use kube::{
+    api::{Api, Patch, PatchParams},
+    Client, ResourceExt,
+};
+use serde_json::json;
+use tracing::{info, warn};
+
+use crate::crd::{NodeType, StellarNode};
+use crate::error::Error;
+
+/// Check if the passphrase secret has been rotated and trigger restart if needed.
+///
+/// Compares the current secret's resourceVersion with the observed version in status.
+/// If they differ, patches the workload (StatefulSet/Deployment) with a restart annotation
+/// and updates the status to track the new version.
+pub async fn handle_passphrase_secret_rotation(
+    client: &Client,
+    node: &StellarNode,
+    dry_run: bool,
+) -> Result<bool> {
+    let Some(secret_ref) = &node.spec.passphrase_secret_ref else {
+        return Ok(false);
+    };
+
+    let namespace = node.namespace().unwrap_or_else(|| "default".to_string());
+    let secrets: Api<Secret> = Api::namespaced(client.clone(), &namespace);
+
+    // Fetch the current secret
+    let secret = match secrets.get(secret_ref).await {
+        Ok(s) => s,
+        Err(kube::Error::Api(e)) if e.code == 404 => {
+            warn!(
+                "Passphrase secret {} not found in namespace {}",
+                secret_ref, namespace
+            );
+            return Ok(false);
+        }
+        Err(e) => return Err(Error::KubeError(e).into()),
+    };
+
+    let current_rv = secret.resource_version();
+    let observed_rv = node
+        .status
+        .as_ref()
+        .and_then(|s| s.observed_passphrase_secret_version.as_deref());
+
+    // If versions match, no rotation needed
+    if observed_rv == current_rv.as_deref() {
+        return Ok(false);
+    }
+
+    info!(
+        "Passphrase secret {} was rotated (rv: {:?} -> {:?}), triggering rolling restart for {}/{}",
+        secret_ref,
+        observed_rv,
+        current_rv,
+        namespace,
+        node.name_any()
+    );
+
+    if dry_run {
+        info!(
+            "[dry-run] Would restart pods for {}/{}",
+            namespace,
+            node.name_any()
+        );
+        return Ok(true);
+    }
+
+    // Trigger rolling restart via pod template annotation
+    let restart_annotation = "stellar.org/passphrase-rotated-at";
+    let annotation_value = current_rv.as_deref().unwrap_or("unknown");
+    let patch = json!({
+        "spec": {
+            "template": {
+                "metadata": {
+                    "annotations": {
+                        restart_annotation: annotation_value
+                    }
+                }
+            }
+        }
+    });
+
+    let pp = if dry_run {
+        PatchParams::apply("stellar-operator").dry_run()
+    } else {
+        PatchParams::apply("stellar-operator")
+    };
+
+    match node.spec.node_type {
+        NodeType::Validator => {
+            let api: Api<StatefulSet> = Api::namespaced(client.clone(), &namespace);
+            if let Err(e) = api
+                .patch(&node.name_any(), &pp, &Patch::Merge(&patch))
+                .await
+            {
+                warn!("Failed to patch StatefulSet for passphrase rotation restart: {e}");
+            }
+        }
+        NodeType::Horizon | NodeType::SorobanRpc => {
+            let api: Api<Deployment> = Api::namespaced(client.clone(), &namespace);
+            if let Err(e) = api
+                .patch(&node.name_any(), &pp, &Patch::Merge(&patch))
+                .await
+            {
+                warn!("Failed to patch Deployment for passphrase rotation restart: {e}");
+            }
+        }
+    }
+
+    // Update status to track the new version
+    let api_sn: Api<StellarNode> = Api::namespaced(client.clone(), &namespace);
+    let status_patch = json!({
+        "status": {
+            "observedPassphraseSecretVersion": current_rv,
+            "lastSecretRotationTime": chrono::Utc::now().to_rfc3339()
+        }
+    });
+
+    api_sn
+        .patch_status(
+            &node.name_any(),
+            &PatchParams::apply("stellar-operator"),
+            &Patch::Merge(&status_patch),
+        )
+        .await
+        .context("Failed to update status after passphrase rotation")?;
+
+    Ok(true)
+}
+
+/// Check if the validator seed secret has been rotated and trigger restart if needed.
+///
+/// Compares the current secret's resourceVersion with the observed version in status.
+/// If they differ, patches the StatefulSet with a restart annotation and updates the status.
+pub async fn handle_seed_secret_rotation(
+    client: &Client,
+    node: &StellarNode,
+    dry_run: bool,
+) -> Result<bool> {
+    // Only applicable to validators
+    if node.spec.node_type != NodeType::Validator {
+        return Ok(false);
+    }
+
+    let Some(validator_config) = &node.spec.validator_config else {
+        return Ok(false);
+    };
+
+    // Check if using legacy seed_secret_ref (not KMS/ESO/CSI)
+    if validator_config.seed_secret_ref.is_empty() {
+        return Ok(false);
+    }
+
+    let namespace = node.namespace().unwrap_or_else(|| "default".to_string());
+    let secrets: Api<Secret> = Api::namespaced(client.clone(), &namespace);
+
+    // Fetch the current secret
+    let secret = match secrets.get(&validator_config.seed_secret_ref).await {
+        Ok(s) => s,
+        Err(kube::Error::Api(e)) if e.code == 404 => {
+            warn!(
+                "Seed secret {} not found in namespace {}",
+                validator_config.seed_secret_ref, namespace
+            );
+            return Ok(false);
+        }
+        Err(e) => return Err(Error::KubeError(e).into()),
+    };
+
+    let current_rv = secret.resource_version();
+    let observed_rv = node
+        .status
+        .as_ref()
+        .and_then(|s| s.observed_seed_secret_version.as_deref());
+
+    // If versions match, no rotation needed
+    if observed_rv == current_rv.as_deref() {
+        return Ok(false);
+    }
+
+    info!(
+        "Seed secret {} was rotated (rv: {:?} -> {:?}), triggering rolling restart for {}/{}",
+        validator_config.seed_secret_ref,
+        observed_rv,
+        current_rv,
+        namespace,
+        node.name_any()
+    );
+
+    if dry_run {
+        info!(
+            "[dry-run] Would restart pods for {}/{}",
+            namespace,
+            node.name_any()
+        );
+        return Ok(true);
+    }
+
+    // Trigger rolling restart via pod template annotation
+    let restart_annotation = "stellar.org/seed-rotated-at";
+    let annotation_value = current_rv.as_deref().unwrap_or("unknown");
+    let patch = json!({
+        "spec": {
+            "template": {
+                "metadata": {
+                    "annotations": {
+                        restart_annotation: annotation_value
+                    }
+                }
+            }
+        }
+    });
+
+    let pp = if dry_run {
+        PatchParams::apply("stellar-operator").dry_run()
+    } else {
+        PatchParams::apply("stellar-operator")
+    };
+
+    let api: Api<StatefulSet> = Api::namespaced(client.clone(), &namespace);
+    if let Err(e) = api
+        .patch(&node.name_any(), &pp, &Patch::Merge(&patch))
+        .await
+    {
+        warn!("Failed to patch StatefulSet for seed rotation restart: {e}");
+    }
+
+    // Update status to track the new version
+    let api_sn: Api<StellarNode> = Api::namespaced(client.clone(), &namespace);
+    let status_patch = json!({
+        "status": {
+            "observedSeedSecretVersion": current_rv,
+            "lastSecretRotationTime": chrono::Utc::now().to_rfc3339()
+        }
+    });
+
+    api_sn
+        .patch_status(
+            &node.name_any(),
+            &PatchParams::apply("stellar-operator"),
+            &Patch::Merge(&status_patch),
+        )
+        .await
+        .context("Failed to update status after seed rotation")?;
+
+    Ok(true)
+}

--- a/src/crd/stellar_node.rs
+++ b/src/crd/stellar_node.rs
@@ -69,6 +69,15 @@ pub struct StellarNodeSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_network_passphrase: Option<String>,
 
+    /// Reference to a Kubernetes Secret containing the network passphrase.
+    /// When set, the operator watches this secret and triggers graceful rolling
+    /// restarts when the secret is rotated. The secret must have a key named
+    /// `NETWORK_PASSPHRASE`.
+    ///
+    /// This takes precedence over `custom_network_passphrase` when both are set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub passphrase_secret_ref: Option<String>,
+
     /// Version of the Stellar software to run (e.g., "v21.0.0").
     pub version: String,
 
@@ -414,6 +423,7 @@ impl Default for StellarNodeSpec {
             label_propagation: None,
             resource_meta: None,
             custom_network_passphrase: None,
+            passphrase_secret_ref: None,
             sidecars: None,
             cert_manager: None,
             probes: None,
@@ -1372,6 +1382,22 @@ pub struct StellarNodeStatus {
     /// Status of the history archive pruning process.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pruning_status: Option<super::types::PruningStatus>,
+
+    /// Observed resource version of the passphrase secret (for rotation detection).
+    /// When this differs from the current secret's resourceVersion, the operator
+    /// triggers a graceful rolling restart.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observed_passphrase_secret_version: Option<String>,
+
+    /// Observed resource version of the validator seed secret (for rotation detection).
+    /// When this differs from the current secret's resourceVersion, the operator
+    /// triggers a graceful rolling restart.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observed_seed_secret_version: Option<String>,
+
+    /// Timestamp of the last secret rotation (RFC3339).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_secret_rotation_time: Option<String>,
 }
 
 /// BGP advertisement status information


### PR DESCRIPTION
Implements #709 - seamless rotation of network passphrases and validator seed keys without manual restarts or downtime.

Changes:
- Add passphrase_secret_ref field to StellarNodeSpec CRD for referencing a Kubernetes Secret containing the network passphrase (key: NETWORK_PASSPHRASE)
- Add observed_passphrase_secret_version, observed_seed_secret_version, and last_secret_rotation_time fields to StellarNodeStatus for rotation tracking
- Add src/controller/secret_watcher.rs module implementing:
  - handle_passphrase_secret_rotation(): detects passphrase secret changes via resourceVersion comparison and triggers graceful rolling restarts via stellar.org/passphrase-rotated-at pod template annotation
  - handle_seed_secret_rotation(): detects validator seed secret changes and triggers graceful rolling restarts via stellar.org/seed-rotated-at annotation; updates status to track observed versions
- Register Secret watch in run_controller() so the controller is notified when any Secret in the watched namespace changes
- Call both rotation handlers in apply_stellar_node() reconciliation loop (step 5c) so every reconcile cycle checks for rotated secrets
- Graceful restart uses Kubernetes rolling update semantics (respects PDB maxUnavailable) ensuring zero downtime during rotation

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (`cargo clippy --all-targets --all-features -- -D warnings` passes)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes (`cargo test`)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have signed-off my commits with the Developer Certificate of Origin (DCO) using `git commit -s`
closes #709
