### PR TITLE
feat: implement data pipeline, API gateway, and Horizon dashboard (#788, #789, #708)

### DIFF
--- a/docs/horizon-dashboard.md
+++ b/docs/horizon-dashboard.md
@@ -1,0 +1,154 @@
+# Horizon API Grafana Dashboard
+
+A pre-built Grafana dashboard for monitoring Horizon API performance, request rates, error rates, and database connection pool health.
+
+## Dashboard File
+
+`monitoring/grafana-horizon.json`
+
+## Panels
+
+| Panel | Type | Description |
+|---|---|---|
+| HTTP Request Rate | Time series | Requests/s broken down by HTTP method and status code |
+| HTTP Error Rate | Stat | Percentage of 4xx/5xx responses |
+| Ingestion Ledger Lag | Stat | How many ledgers Horizon is behind the network |
+| Request Latency (p50/p95/p99) | Time series | HTTP latency percentiles per route |
+| Request Latency Heatmap | Heatmap | Full latency distribution over time |
+| DB Connection Pool | Time series | Open, in-use, and idle DB connections |
+| DB Query Duration (p50/p95/p99) | Time series | Database query latency percentiles per query type |
+| DB Error Rate | Time series | Rate of database errors by type |
+| Ingestion Throughput | Time series | Ledgers and transactions ingested per second |
+| Ledger Ingestion Duration | Time series | Time taken to ingest each ledger (p50/p95/p99) |
+
+## Prometheus Metrics Required
+
+Horizon must expose the following metrics to Prometheus:
+
+```
+horizon_requests_total{method, status_code, route, namespace}
+horizon_request_duration_seconds_bucket{route, namespace}
+horizon_ingest_ledger_lag{namespace}
+horizon_ingest_ledgers_total{namespace}
+horizon_ingest_transactions_total{namespace}
+horizon_ingest_ledger_duration_seconds_bucket{namespace}
+horizon_db_pool_open_connections{namespace}
+horizon_db_pool_in_use{namespace}
+horizon_db_pool_idle{namespace}
+horizon_db_query_duration_seconds_bucket{query_type, namespace}
+horizon_db_errors_total{error_type, namespace}
+```
+
+Configure Horizon's `--metrics-port` (default `6060`) and add a Prometheus `scrape_config`:
+
+```yaml
+scrape_configs:
+  - job_name: horizon
+    kubernetes_sd_configs:
+      - role: pod
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        regex: horizon
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+        target_label: __address__
+        replacement: "${1}:6060"
+```
+
+## Importing the Dashboard
+
+### Via Grafana UI
+
+1. Open your Grafana instance.
+2. Go to **Dashboards → Import**.
+3. Click **Upload JSON file** and select `monitoring/grafana-horizon.json`.
+4. Select your **Prometheus** data source from the dropdown.
+5. Click **Import**.
+
+### Via Grafana API
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $GRAFANA_API_KEY" \
+  -d "{\"dashboard\": $(cat monitoring/grafana-horizon.json), \"overwrite\": true, \"folderId\": 0}" \
+  http://<grafana-host>/api/dashboards/import
+```
+
+### Via Helm (kube-prometheus-stack)
+
+Add the dashboard as a ConfigMap so the Grafana sidecar picks it up automatically:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-horizon-dashboard
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  grafana-horizon.json: |
+    # paste contents of monitoring/grafana-horizon.json here
+```
+
+Or reference the file in your Helm values:
+
+```yaml
+grafana:
+  dashboardsConfigMaps:
+    horizon: grafana-horizon-dashboard
+```
+
+## Template Variables
+
+| Variable | Description |
+|---|---|
+| `datasource` | Prometheus data source to query |
+| `namespace` | Kubernetes namespace(s) to filter (supports multi-select) |
+
+## Alerting
+
+Example Prometheus alerting rules for Horizon:
+
+```yaml
+groups:
+  - name: horizon
+    rules:
+      - alert: HorizonHighErrorRate
+        expr: |
+          100 * sum(rate(horizon_requests_total{status_code=~"[45].."}[5m]))
+              / sum(rate(horizon_requests_total[5m])) > 5
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Horizon error rate above 5%"
+
+      - alert: HorizonHighLedgerLag
+        expr: horizon_ingest_ledger_lag > 20
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Horizon ingestion lagging behind network by {{ $value }} ledgers"
+
+      - alert: HorizonHighP99Latency
+        expr: |
+          histogram_quantile(0.99,
+            sum(rate(horizon_request_duration_seconds_bucket[5m])) by (le)
+          ) > 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Horizon p99 latency above 2s"
+
+      - alert: HorizonDBPoolExhausted
+        expr: horizon_db_pool_idle == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Horizon DB connection pool has no idle connections"
+```

--- a/monitoring/grafana-horizon.json
+++ b/monitoring/grafana-horizon.json
@@ -1,0 +1,377 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Horizon API performance, request rates, error rates, and database connection pool metrics",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Total HTTP requests per second to Horizon",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2 },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 1 },
+      "id": 1,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum(rate(horizon_requests_total{namespace=~\"$namespace\"}[5m])) by (method, status_code)",
+          "legendFormat": "{{method}} {{status_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "HTTP error rate (4xx + 5xx) as a percentage of total requests",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "unit": "percent",
+          "max": 100,
+          "min": 0
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 1 },
+      "id": 2,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "background" },
+      "targets": [
+        {
+          "expr": "100 * sum(rate(horizon_requests_total{namespace=~\"$namespace\", status_code=~\"[45]..\"}[5m])) / sum(rate(horizon_requests_total{namespace=~\"$namespace\"}[5m]))",
+          "legendFormat": "Error Rate %",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Error Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Horizon ingestion lag — how many ledgers behind the network",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 1 },
+      "id": 3,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "background" },
+      "targets": [
+        {
+          "expr": "horizon_ingest_ledger_lag{namespace=~\"$namespace\"}",
+          "legendFormat": "Ledger Lag",
+          "refId": "A"
+        }
+      ],
+      "title": "Ingestion Ledger Lag",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 101,
+      "title": "HTTP Latency",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "HTTP request latency percentiles (p50, p95, p99)",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2 },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "id": 4,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(horizon_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le, route))",
+          "legendFormat": "p50 {{route}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(horizon_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le, route))",
+          "legendFormat": "p95 {{route}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(horizon_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le, route))",
+          "legendFormat": "p99 {{route}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Request Latency (p50/p95/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Latency heatmap for all Horizon HTTP requests",
+      "fieldConfig": {
+        "defaults": { "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } }, "unit": "s" }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "id": 5,
+      "options": { "calculate": false, "cellGap": 1, "color": { "exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "scale": "exponential", "scheme": "Oranges", "steps": 64 }, "exemplars": { "color": "rgba(255,0,255,0.7)" }, "filterValues": { "le": 1e-9 }, "legend": { "show": true }, "rowsFrame": { "layout": "auto" }, "tooltip": { "mode": "single", "showColorScale": false, "yHistogram": false }, "yAxis": { "axisPlacement": "left", "decimals": 0, "reverse": false, "unit": "s" } },
+      "targets": [
+        {
+          "expr": "sum(increase(horizon_request_duration_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Latency Heatmap",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
+      "id": 102,
+      "title": "Database",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Active and idle database connections in the pool",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2 },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 19 },
+      "id": 6,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "horizon_db_pool_open_connections{namespace=~\"$namespace\"}",
+          "legendFormat": "Open",
+          "refId": "A"
+        },
+        {
+          "expr": "horizon_db_pool_in_use{namespace=~\"$namespace\"}",
+          "legendFormat": "In Use",
+          "refId": "B"
+        },
+        {
+          "expr": "horizon_db_pool_idle{namespace=~\"$namespace\"}",
+          "legendFormat": "Idle",
+          "refId": "C"
+        }
+      ],
+      "title": "DB Connection Pool",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Database query duration percentiles",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2 },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 19 },
+      "id": 7,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(horizon_db_query_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le, query_type))",
+          "legendFormat": "p50 {{query_type}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(horizon_db_query_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le, query_type))",
+          "legendFormat": "p95 {{query_type}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(horizon_db_query_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le, query_type))",
+          "legendFormat": "p99 {{query_type}}",
+          "refId": "C"
+        }
+      ],
+      "title": "DB Query Duration (p50/p95/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Rate of database errors",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2 },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 19 },
+      "id": 8,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum(rate(horizon_db_errors_total{namespace=~\"$namespace\"}[5m])) by (error_type)",
+          "legendFormat": "{{error_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "DB Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
+      "id": 103,
+      "title": "Ingestion & Ledger",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Rate of ledgers ingested per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2 },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
+      "id": 9,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "rate(horizon_ingest_ledgers_total{namespace=~\"$namespace\"}[5m])",
+          "legendFormat": "Ledgers/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(horizon_ingest_transactions_total{namespace=~\"$namespace\"}[5m])",
+          "legendFormat": "Transactions/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Ingestion Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Time taken to ingest each ledger",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2 },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 28 },
+      "id": 10,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(horizon_ingest_ledger_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(horizon_ingest_ledger_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(horizon_ingest_ledger_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Ledger Ingestion Duration",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["stellar", "horizon", "api"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource",
+        "label": "Prometheus"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "definition": "label_values(horizon_requests_total, namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "namespace",
+        "query": "label_values(horizon_requests_total, namespace)",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query",
+        "label": "Namespace"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Horizon API - Performance & Database",
+  "uid": "stellar-horizon-metrics",
+  "version": 1
+}

--- a/src/api_gateway/analytics.rs
+++ b/src/api_gateway/analytics.rs
@@ -1,0 +1,131 @@
+//! API analytics and usage tracking.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+
+/// A single recorded API request event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequestEvent {
+    pub timestamp: String,
+    pub route_id: String,
+    pub method: String,
+    pub path: String,
+    pub status: u16,
+    pub latency_ms: u64,
+    pub api_key_id: Option<String>,
+    pub version: String,
+}
+
+/// Aggregated usage stats per route.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RouteStats {
+    pub total_requests: u64,
+    pub error_count: u64,
+    pub total_latency_ms: u64,
+}
+
+impl RouteStats {
+    pub fn mean_latency_ms(&self) -> u64 {
+        if self.total_requests == 0 {
+            0
+        } else {
+            self.total_latency_ms / self.total_requests
+        }
+    }
+}
+
+/// Thread-safe analytics store.
+#[derive(Clone, Default)]
+pub struct AnalyticsStore {
+    events: Arc<RwLock<Vec<RequestEvent>>>,
+    stats: Arc<RwLock<HashMap<String, RouteStats>>>,
+    capacity: usize,
+}
+
+impl AnalyticsStore {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            events: Arc::new(RwLock::new(Vec::with_capacity(capacity))),
+            stats: Arc::new(RwLock::new(HashMap::new())),
+            capacity,
+        }
+    }
+
+    pub async fn record(
+        &self,
+        route_id: impl Into<String>,
+        method: impl Into<String>,
+        path: impl Into<String>,
+        status: u16,
+        latency: Duration,
+        api_key_id: Option<String>,
+        version: impl Into<String>,
+    ) {
+        let route_id = route_id.into();
+        let latency_ms = latency.as_millis() as u64;
+
+        let event = RequestEvent {
+            timestamp: Utc::now().to_rfc3339(),
+            route_id: route_id.clone(),
+            method: method.into(),
+            path: path.into(),
+            status,
+            latency_ms,
+            api_key_id,
+            version: version.into(),
+        };
+
+        // Update aggregated stats
+        {
+            let mut stats = self.stats.write().await;
+            let entry = stats.entry(route_id).or_default();
+            entry.total_requests += 1;
+            entry.total_latency_ms += latency_ms;
+            if status >= 400 {
+                entry.error_count += 1;
+            }
+        }
+
+        // Append event with ring-buffer eviction
+        let mut events = self.events.write().await;
+        if events.len() >= self.capacity {
+            events.remove(0);
+        }
+        events.push(event);
+    }
+
+    pub async fn stats_snapshot(&self) -> HashMap<String, RouteStats> {
+        self.stats.read().await.clone()
+    }
+
+    pub async fn recent_events(&self, limit: usize) -> Vec<RequestEvent> {
+        let events = self.events.read().await;
+        let start = events.len().saturating_sub(limit);
+        events[start..].to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn records_and_aggregates() {
+        let store = AnalyticsStore::new(100);
+        store
+            .record("route-1", "GET", "/api/v1/tx", 200, Duration::from_millis(50), None, "v1")
+            .await;
+        store
+            .record("route-1", "GET", "/api/v1/tx", 500, Duration::from_millis(100), None, "v1")
+            .await;
+        let stats = store.stats_snapshot().await;
+        let s = &stats["route-1"];
+        assert_eq!(s.total_requests, 2);
+        assert_eq!(s.error_count, 1);
+        assert_eq!(s.mean_latency_ms(), 75);
+    }
+}

--- a/src/api_gateway/auth.rs
+++ b/src/api_gateway/auth.rs
@@ -1,0 +1,152 @@
+//! API key management and authentication.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// An API key with associated metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKey {
+    pub id: String,
+    /// SHA-256 hash of the raw key value (never store plaintext)
+    pub key_hash: String,
+    pub owner: String,
+    pub scopes: Vec<String>,
+    pub created_at: String,
+    pub expires_at: Option<String>,
+    pub active: bool,
+    /// Custom rate-limit override (requests/sec); None = use default
+    pub rate_limit_rps: Option<u32>,
+}
+
+impl ApiKey {
+    /// Create a new API key, returning both the [`ApiKey`] record and the
+    /// raw key string (shown once to the caller).
+    pub fn generate(owner: impl Into<String>, scopes: Vec<String>) -> (Self, String) {
+        let raw = format!(
+            "sk_{:x}",
+            rand::random::<u128>()
+        );
+        let key_hash = hex::encode(Sha256::digest(raw.as_bytes()));
+        let id = format!("key_{:x}", rand::random::<u64>());
+        let key = ApiKey {
+            id,
+            key_hash,
+            owner: owner.into(),
+            scopes,
+            created_at: Utc::now().to_rfc3339(),
+            expires_at: None,
+            active: true,
+            rate_limit_rps: None,
+        };
+        (key, raw)
+    }
+
+    /// Verify a raw key string against this record.
+    pub fn verify(&self, raw: &str) -> bool {
+        let hash = hex::encode(Sha256::digest(raw.as_bytes()));
+        self.active && hash == self.key_hash
+    }
+
+    pub fn is_expired(&self) -> bool {
+        if let Some(exp) = &self.expires_at {
+            if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(exp) {
+                return Utc::now() > dt;
+            }
+        }
+        false
+    }
+}
+
+/// Thread-safe in-memory API key store.
+#[derive(Clone, Default)]
+pub struct ApiKeyStore {
+    keys: Arc<RwLock<HashMap<String, ApiKey>>>,
+}
+
+impl ApiKeyStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add or replace a key.
+    pub async fn upsert(&self, key: ApiKey) {
+        self.keys.write().await.insert(key.id.clone(), key);
+    }
+
+    /// Revoke a key by ID.
+    pub async fn revoke(&self, id: &str) -> bool {
+        let mut guard = self.keys.write().await;
+        if let Some(k) = guard.get_mut(id) {
+            k.active = false;
+            return true;
+        }
+        false
+    }
+
+    /// Authenticate a raw key string.  Returns the matching [`ApiKey`] if
+    /// valid and not expired.
+    pub async fn authenticate(&self, raw: &str) -> Option<ApiKey> {
+        let guard = self.keys.read().await;
+        guard
+            .values()
+            .find(|k| k.verify(raw) && !k.is_expired())
+            .cloned()
+    }
+
+    /// List all keys (without exposing hashes).
+    pub async fn list(&self) -> Vec<ApiKeyInfo> {
+        self.keys
+            .read()
+            .await
+            .values()
+            .map(|k| ApiKeyInfo {
+                id: k.id.clone(),
+                owner: k.owner.clone(),
+                scopes: k.scopes.clone(),
+                active: k.active,
+                created_at: k.created_at.clone(),
+                expires_at: k.expires_at.clone(),
+            })
+            .collect()
+    }
+}
+
+/// Public-safe key info (no hash).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyInfo {
+    pub id: String,
+    pub owner: String,
+    pub scopes: Vec<String>,
+    pub active: bool,
+    pub created_at: String,
+    pub expires_at: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn generate_and_authenticate() {
+        let store = ApiKeyStore::new();
+        let (key, raw) = ApiKey::generate("test-owner", vec!["read".into()]);
+        store.upsert(key).await;
+        let found = store.authenticate(&raw).await;
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().owner, "test-owner");
+    }
+
+    #[tokio::test]
+    async fn revoke_key() {
+        let store = ApiKeyStore::new();
+        let (key, raw) = ApiKey::generate("owner", vec![]);
+        let id = key.id.clone();
+        store.upsert(key).await;
+        store.revoke(&id).await;
+        assert!(store.authenticate(&raw).await.is_none());
+    }
+}

--- a/src/api_gateway/config.rs
+++ b/src/api_gateway/config.rs
@@ -1,0 +1,98 @@
+//! Gateway configuration types.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayConfig {
+    /// Address to bind the gateway listener
+    pub bind_addr: String,
+    pub routes: Vec<RouteConfig>,
+    pub rate_limiting: RateLimitConfig,
+    pub versioning: VersioningConfig,
+    /// Enable request/response logging for analytics
+    pub analytics_enabled: bool,
+}
+
+impl Default for GatewayConfig {
+    fn default() -> Self {
+        Self {
+            bind_addr: "0.0.0.0:8080".into(),
+            routes: vec![],
+            rate_limiting: RateLimitConfig::default(),
+            versioning: VersioningConfig::default(),
+            analytics_enabled: true,
+        }
+    }
+}
+
+/// A single route definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RouteConfig {
+    /// Route ID used in analytics and logs
+    pub id: String,
+    /// Path prefix to match (e.g. "/api/v1/transactions")
+    pub path_prefix: String,
+    /// HTTP methods to match; empty = all methods
+    pub methods: Vec<String>,
+    /// Upstream URL to proxy to
+    pub upstream: String,
+    /// Protocol of the upstream service
+    pub protocol: Protocol,
+    /// API version this route belongs to
+    pub version: String,
+    /// Header-based routing predicates (all must match)
+    pub header_predicates: HashMap<String, String>,
+    /// Whether this route is deprecated
+    pub deprecated: bool,
+    /// Sunset date for deprecated routes (ISO-8601)
+    pub sunset_date: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Protocol {
+    Rest,
+    Grpc,
+    GraphQL,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimitConfig {
+    /// Default requests per second per API key
+    pub default_rps: u32,
+    /// Default burst size
+    pub default_burst: u32,
+    /// Per-key overrides: api_key_id → rps
+    pub key_overrides: HashMap<String, u32>,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            default_rps: 100,
+            default_burst: 200,
+            key_overrides: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersioningConfig {
+    /// Current stable version (e.g. "v2")
+    pub current_version: String,
+    /// Versions that are deprecated but still served
+    pub deprecated_versions: Vec<String>,
+    /// Versions that are no longer served (return 410 Gone)
+    pub sunset_versions: Vec<String>,
+}
+
+impl Default for VersioningConfig {
+    fn default() -> Self {
+        Self {
+            current_version: "v1".into(),
+            deprecated_versions: vec![],
+            sunset_versions: vec![],
+        }
+    }
+}

--- a/src/api_gateway/mod.rs
+++ b/src/api_gateway/mod.rs
@@ -1,0 +1,28 @@
+//! API gateway with intelligent routing, protocol transformation, versioning,
+//! rate limiting, analytics, and API key management (#789).
+//!
+//! Architecture:
+//! ```
+//! Client Request
+//!   → API Key Auth
+//!   → Rate Limiter
+//!   → Version Router  (v1 / v2 / deprecated)
+//!   → Protocol Transform  (REST / gRPC / GraphQL)
+//!   → Request Validator
+//!   → Upstream Proxy
+//!   → Response Transform
+//!   → Analytics Recorder
+//! ```
+
+pub mod analytics;
+pub mod auth;
+pub mod config;
+pub mod router;
+pub mod server;
+pub mod transform;
+pub mod versioning;
+
+pub use config::GatewayConfig;
+pub use server::ApiGateway;
+pub use auth::{ApiKey, ApiKeyStore};
+pub use router::RouteMatch;

--- a/src/api_gateway/router.rs
+++ b/src/api_gateway/router.rs
@@ -1,0 +1,132 @@
+//! Intelligent request routing based on path, method, headers, and version.
+
+use crate::api_gateway::config::{RouteConfig, VersioningConfig};
+use std::collections::HashMap;
+
+/// The result of matching a request against the route table.
+#[derive(Debug, Clone)]
+pub struct RouteMatch<'a> {
+    pub route: &'a RouteConfig,
+    /// Remaining path after stripping the matched prefix
+    pub remaining_path: String,
+}
+
+/// Route table built from [`RouteConfig`] entries.
+pub struct Router {
+    routes: Vec<RouteConfig>,
+    versioning: VersioningConfig,
+}
+
+impl Router {
+    pub fn new(routes: Vec<RouteConfig>, versioning: VersioningConfig) -> Self {
+        Self { routes, versioning }
+    }
+
+    /// Match an incoming request to a route.
+    ///
+    /// Matching priority:
+    /// 1. Longest path prefix wins
+    /// 2. Method must be in the allowed list (or list is empty = all)
+    /// 3. All header predicates must match
+    /// 4. Sunset versions return `None` (caller should respond 410)
+    pub fn match_route<'a>(
+        &'a self,
+        path: &str,
+        method: &str,
+        headers: &HashMap<String, String>,
+    ) -> MatchResult<'a> {
+        // Check if the path starts with a sunset version prefix
+        for sv in &self.versioning.sunset_versions {
+            if path.contains(&format!("/{sv}/")) || path.ends_with(&format!("/{sv}")) {
+                return MatchResult::Sunset(sv.clone());
+            }
+        }
+
+        let mut best: Option<&RouteConfig> = None;
+        let mut best_len = 0usize;
+
+        for route in &self.routes {
+            if !path.starts_with(&route.path_prefix) {
+                continue;
+            }
+            if !route.methods.is_empty()
+                && !route.methods.iter().any(|m| m.eq_ignore_ascii_case(method))
+            {
+                continue;
+            }
+            // Header predicates
+            if !route.header_predicates.iter().all(|(k, v)| {
+                headers
+                    .get(k.as_str())
+                    .map(|hv| hv == v)
+                    .unwrap_or(false)
+            }) {
+                continue;
+            }
+            if route.path_prefix.len() > best_len {
+                best_len = route.path_prefix.len();
+                best = Some(route);
+            }
+        }
+
+        match best {
+            None => MatchResult::NotFound,
+            Some(route) => {
+                let remaining = path[route.path_prefix.len()..].to_string();
+                MatchResult::Matched(RouteMatch { route, remaining_path: remaining })
+            }
+        }
+    }
+}
+
+pub enum MatchResult<'a> {
+    Matched(RouteMatch<'a>),
+    NotFound,
+    /// Version has been sunset — respond 410 Gone
+    Sunset(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api_gateway::config::{Protocol, VersioningConfig};
+
+    fn make_route(prefix: &str, version: &str) -> RouteConfig {
+        RouteConfig {
+            id: prefix.into(),
+            path_prefix: prefix.into(),
+            methods: vec![],
+            upstream: "http://upstream".into(),
+            protocol: Protocol::Rest,
+            version: version.into(),
+            header_predicates: HashMap::new(),
+            deprecated: false,
+            sunset_date: None,
+        }
+    }
+
+    #[test]
+    fn longest_prefix_wins() {
+        let router = Router::new(
+            vec![
+                make_route("/api/v1", "v1"),
+                make_route("/api/v1/transactions", "v1"),
+            ],
+            VersioningConfig::default(),
+        );
+        let m = router.match_route("/api/v1/transactions/abc", "GET", &HashMap::new());
+        match m {
+            MatchResult::Matched(r) => assert_eq!(r.route.path_prefix, "/api/v1/transactions"),
+            _ => panic!("expected match"),
+        }
+    }
+
+    #[test]
+    fn no_match_returns_not_found() {
+        let router = Router::new(vec![], VersioningConfig::default());
+        assert!(matches!(
+            router.match_route("/unknown", "GET", &HashMap::new()),
+            MatchResult::NotFound
+        ));
+    }
+}

--- a/src/api_gateway/server.rs
+++ b/src/api_gateway/server.rs
@@ -1,0 +1,296 @@
+//! API gateway server: Axum-based HTTP server wiring all gateway components.
+
+use crate::api_gateway::{
+    analytics::AnalyticsStore,
+    auth::ApiKeyStore,
+    config::GatewayConfig,
+    router::{MatchResult, Router},
+    transform::{transform_request, transform_response},
+    versioning::{check_version, deprecation_headers, VersionStatus},
+};
+use axum::{
+    body::Body,
+    extract::{Request, State},
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::any,
+    Router as AxumRouter,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+
+// ── Rate limiter ──────────────────────────────────────────────────────────────
+
+/// Simple token-bucket rate limiter per API key.
+#[derive(Default)]
+struct RateLimiter {
+    /// key_id → (tokens, last_refill_secs)
+    buckets: RwLock<HashMap<String, (f64, u64)>>,
+}
+
+impl RateLimiter {
+    fn now_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    /// Returns `true` if the request is allowed.
+    async fn check(&self, key_id: &str, rps: f64, burst: f64) -> bool {
+        let now = Self::now_secs();
+        let mut buckets = self.buckets.write().await;
+        let entry = buckets.entry(key_id.to_string()).or_insert((burst, now));
+        let elapsed = now.saturating_sub(entry.1) as f64;
+        entry.0 = (entry.0 + elapsed * rps).min(burst);
+        entry.1 = now;
+        if entry.0 >= 1.0 {
+            entry.0 -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+// ── Shared gateway state ──────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct GatewayState {
+    router: Arc<Router>,
+    key_store: ApiKeyStore,
+    analytics: AnalyticsStore,
+    rate_limiter: Arc<RateLimiter>,
+    config: Arc<GatewayConfig>,
+    http_client: reqwest::Client,
+}
+
+// ── ApiGateway ────────────────────────────────────────────────────────────────
+
+/// The API gateway.
+pub struct ApiGateway {
+    config: GatewayConfig,
+    key_store: ApiKeyStore,
+}
+
+impl ApiGateway {
+    pub fn new(config: GatewayConfig) -> Self {
+        Self {
+            config,
+            key_store: ApiKeyStore::new(),
+        }
+    }
+
+    /// Access the key store to pre-populate API keys.
+    pub fn key_store(&self) -> &ApiKeyStore {
+        &self.key_store
+    }
+
+    /// Build and return the Axum router (useful for embedding in an existing server).
+    pub fn into_router(self) -> AxumRouter {
+        let state = GatewayState {
+            router: Arc::new(Router::new(
+                self.config.routes.clone(),
+                self.config.versioning.clone(),
+            )),
+            key_store: self.key_store,
+            analytics: AnalyticsStore::new(50_000),
+            rate_limiter: Arc::new(RateLimiter::default()),
+            config: Arc::new(self.config),
+            http_client: reqwest::Client::new(),
+        };
+
+        AxumRouter::new()
+            .route("/{*path}", any(handle_request))
+            .route("/", any(handle_request))
+            // Management endpoints
+            .route("/_gateway/keys", axum::routing::get(list_keys))
+            .route("/_gateway/analytics", axum::routing::get(get_analytics))
+            .with_state(state)
+    }
+
+    /// Start the gateway on the configured bind address.
+    pub async fn serve(self) -> Result<(), crate::error::Error> {
+        let addr = self.config.bind_addr.clone();
+        let app = self.into_router();
+        let listener = tokio::net::TcpListener::bind(&addr)
+            .await
+            .map_err(|e| crate::error::Error::ConfigError(e.to_string()))?;
+        info!(addr, "API gateway listening");
+        axum::serve(listener, app)
+            .await
+            .map_err(|e| crate::error::Error::ConfigError(e.to_string()))
+    }
+}
+
+// ── Request handler ───────────────────────────────────────────────────────────
+
+async fn handle_request(State(state): State<GatewayState>, req: Request) -> Response {
+    let start = Instant::now();
+    let method = req.method().to_string();
+    let path = req.uri().path().to_string();
+
+    // Extract headers as a plain map for routing predicates
+    let headers: HashMap<String, String> = req
+        .headers()
+        .iter()
+        .filter_map(|(k, v)| {
+            v.to_str().ok().map(|v| (k.as_str().to_string(), v.to_string()))
+        })
+        .collect();
+
+    // API key authentication
+    let raw_key = headers
+        .get("x-api-key")
+        .or_else(|| headers.get("authorization"))
+        .cloned()
+        .unwrap_or_default();
+    let raw_key = raw_key.trim_start_matches("Bearer ").to_string();
+
+    let api_key = state.key_store.authenticate(&raw_key).await;
+    if api_key.is_none() && !raw_key.is_empty() {
+        return (StatusCode::UNAUTHORIZED, "Invalid API key").into_response();
+    }
+    let key_id = api_key.as_ref().map(|k| k.id.clone());
+
+    // Rate limiting
+    if let Some(key) = &api_key {
+        let rps = state
+            .config
+            .rate_limiting
+            .key_overrides
+            .get(&key.id)
+            .copied()
+            .unwrap_or(state.config.rate_limiting.default_rps) as f64;
+        let burst = state.config.rate_limiting.default_burst as f64;
+        if !state.rate_limiter.check(&key.id, rps, burst).await {
+            warn!(key_id = %key.id, "rate limit exceeded");
+            return (StatusCode::TOO_MANY_REQUESTS, "Rate limit exceeded").into_response();
+        }
+    }
+
+    // Route matching
+    let match_result = state.router.match_route(&path, &method, &headers);
+    let route_match = match match_result {
+        MatchResult::NotFound => {
+            return (StatusCode::NOT_FOUND, "No matching route").into_response();
+        }
+        MatchResult::Sunset(version) => {
+            return (
+                StatusCode::GONE,
+                format!("API version {version} has been sunset"),
+            )
+                .into_response();
+        }
+        MatchResult::Matched(m) => m,
+    };
+
+    let route = route_match.route;
+
+    // Version deprecation headers
+    let version_status = check_version(&route.version, &state.config.versioning);
+    let mut extra_headers: Vec<(String, String)> = vec![];
+    if let VersionStatus::Deprecated { sunset_date } = &version_status {
+        extra_headers.extend(deprecation_headers(
+            route.sunset_date.as_deref().or(sunset_date.as_deref()),
+        ));
+    }
+
+    // Read request body
+    let (parts, body) = req.into_parts();
+    let body_bytes = match axum::body::to_bytes(body, 10 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Failed to read body").into_response(),
+    };
+
+    // Protocol transformation (client → upstream)
+    let client_protocol = &crate::api_gateway::config::Protocol::Rest; // inferred from Content-Type in production
+    let normalized = match transform_request(&body_bytes, client_protocol, &route.protocol) {
+        Ok(n) => n,
+        Err(e) => {
+            return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
+        }
+    };
+
+    // Proxy to upstream
+    let upstream_url = format!("{}{}", route.upstream, route_match.remaining_path);
+    let upstream_resp = state
+        .http_client
+        .request(
+            reqwest::Method::from_bytes(method.as_bytes()).unwrap_or(reqwest::Method::GET),
+            &upstream_url,
+        )
+        .header("Content-Type", &normalized.content_type)
+        .body(serde_json::to_vec(&normalized.body).unwrap_or_default())
+        .send()
+        .await;
+
+    let (status_code, resp_body) = match upstream_resp {
+        Ok(r) => {
+            let status = r.status().as_u16();
+            let body = r.bytes().await.unwrap_or_default();
+            (status, body.to_vec())
+        }
+        Err(e) => {
+            warn!(upstream = %upstream_url, error = %e, "upstream request failed");
+            return (StatusCode::BAD_GATEWAY, "Upstream error").into_response();
+        }
+    };
+
+    // Protocol transformation (upstream → client)
+    let normalized_resp =
+        match transform_response(&resp_body, &route.protocol, client_protocol, status_code) {
+            Ok(r) => r,
+            Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, "Transform error").into_response(),
+        };
+
+    // Analytics
+    if state.config.analytics_enabled {
+        state
+            .analytics
+            .record(
+                &route.id,
+                &method,
+                &path,
+                status_code,
+                start.elapsed(),
+                key_id,
+                &route.version,
+            )
+            .await;
+    }
+
+    // Build response
+    let status = StatusCode::from_u16(status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let mut response = (
+        status,
+        serde_json::to_vec(&normalized_resp.body).unwrap_or_default(),
+    )
+        .into_response();
+
+    for (k, v) in &extra_headers {
+        if let (Ok(name), Ok(val)) = (
+            HeaderName::from_bytes(k.as_bytes()),
+            HeaderValue::from_str(v),
+        ) {
+            response.headers_mut().insert(name, val);
+        }
+    }
+
+    response
+}
+
+// ── Management handlers ───────────────────────────────────────────────────────
+
+async fn list_keys(State(state): State<GatewayState>) -> impl IntoResponse {
+    let keys = state.key_store.list().await;
+    axum::Json(keys)
+}
+
+async fn get_analytics(State(state): State<GatewayState>) -> impl IntoResponse {
+    let stats = state.analytics.stats_snapshot().await;
+    axum::Json(stats)
+}

--- a/src/api_gateway/transform.rs
+++ b/src/api_gateway/transform.rs
@@ -1,0 +1,111 @@
+//! Protocol transformation: REST ↔ gRPC ↔ GraphQL request/response adapters.
+
+use crate::api_gateway::config::Protocol;
+use serde_json::Value;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum TransformError {
+    #[error("unsupported protocol transformation: {0:?} → {1:?}")]
+    Unsupported(Protocol, Protocol),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("transform error: {0}")]
+    Other(String),
+}
+
+/// Normalised representation of a gateway request body.
+#[derive(Debug, Clone)]
+pub struct NormalizedRequest {
+    pub body: Value,
+    pub content_type: String,
+}
+
+/// Normalised representation of an upstream response body.
+#[derive(Debug, Clone)]
+pub struct NormalizedResponse {
+    pub body: Value,
+    pub content_type: String,
+    pub status: u16,
+}
+
+/// Transform an incoming request body from `from_protocol` into the format
+/// expected by the upstream `to_protocol`.
+pub fn transform_request(
+    raw_body: &[u8],
+    from: &Protocol,
+    to: &Protocol,
+) -> Result<NormalizedRequest, TransformError> {
+    match (from, to) {
+        // REST → REST: pass through, just parse JSON
+        (Protocol::Rest, Protocol::Rest) => {
+            let body: Value = if raw_body.is_empty() {
+                Value::Null
+            } else {
+                serde_json::from_slice(raw_body).map_err(TransformError::Serialization)?
+            };
+            Ok(NormalizedRequest {
+                body,
+                content_type: "application/json".into(),
+            })
+        }
+        // GraphQL → REST: unwrap the `query` field and map to REST params
+        (Protocol::GraphQL, Protocol::Rest) => {
+            let gql: Value = serde_json::from_slice(raw_body)?;
+            let query = gql
+                .get("query")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let variables = gql.get("variables").cloned().unwrap_or(Value::Null);
+            Ok(NormalizedRequest {
+                body: serde_json::json!({ "query": query, "variables": variables }),
+                content_type: "application/json".into(),
+            })
+        }
+        // gRPC → REST: decode JSON-encoded protobuf body (grpc-gateway style)
+        (Protocol::Grpc, Protocol::Rest) => {
+            let body: Value = if raw_body.is_empty() {
+                Value::Null
+            } else {
+                serde_json::from_slice(raw_body).map_err(TransformError::Serialization)?
+            };
+            Ok(NormalizedRequest {
+                body,
+                content_type: "application/json".into(),
+            })
+        }
+        _ => Err(TransformError::Unsupported(from.clone(), to.clone())),
+    }
+}
+
+/// Transform an upstream response body from `upstream_protocol` back to the
+/// format expected by the client (`client_protocol`).
+pub fn transform_response(
+    upstream_body: &[u8],
+    upstream_protocol: &Protocol,
+    client_protocol: &Protocol,
+    status: u16,
+) -> Result<NormalizedResponse, TransformError> {
+    let body: Value = if upstream_body.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(upstream_body).unwrap_or(Value::Null)
+    };
+
+    match (upstream_protocol, client_protocol) {
+        (Protocol::Rest, Protocol::GraphQL) => {
+            // Wrap REST response in a GraphQL `data` envelope
+            Ok(NormalizedResponse {
+                body: serde_json::json!({ "data": body }),
+                content_type: "application/json".into(),
+                status,
+            })
+        }
+        _ => Ok(NormalizedResponse {
+            body,
+            content_type: "application/json".into(),
+            status,
+        }),
+    }
+}

--- a/src/api_gateway/versioning.rs
+++ b/src/api_gateway/versioning.rs
@@ -1,0 +1,50 @@
+//! API versioning and deprecation management.
+
+use crate::api_gateway::config::VersioningConfig;
+
+/// Outcome of a version check.
+#[derive(Debug, PartialEq, Eq)]
+pub enum VersionStatus {
+    Current,
+    Deprecated { sunset_date: Option<String> },
+    Sunset,
+}
+
+pub fn check_version(version: &str, cfg: &VersioningConfig) -> VersionStatus {
+    if cfg.sunset_versions.iter().any(|v| v == version) {
+        return VersionStatus::Sunset;
+    }
+    if cfg.deprecated_versions.iter().any(|v| v == version) {
+        return VersionStatus::Deprecated { sunset_date: None };
+    }
+    VersionStatus::Current
+}
+
+/// Build the `Deprecation` and `Sunset` response headers for deprecated routes.
+pub fn deprecation_headers(sunset_date: Option<&str>) -> Vec<(String, String)> {
+    let mut headers = vec![("Deprecation".into(), "true".into())];
+    if let Some(date) = sunset_date {
+        headers.push(("Sunset".into(), date.into()));
+    }
+    headers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_sunset() {
+        let cfg = VersioningConfig {
+            current_version: "v2".into(),
+            deprecated_versions: vec!["v1".into()],
+            sunset_versions: vec!["v0".into()],
+        };
+        assert_eq!(check_version("v0", &cfg), VersionStatus::Sunset);
+        assert_eq!(
+            check_version("v1", &cfg),
+            VersionStatus::Deprecated { sunset_date: None }
+        );
+        assert_eq!(check_version("v2", &cfg), VersionStatus::Current);
+    }
+}

--- a/src/data_pipeline/config.rs
+++ b/src/data_pipeline/config.rs
@@ -1,0 +1,129 @@
+//! Pipeline configuration types.
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level pipeline configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineConfig {
+    pub kafka: KafkaConfig,
+    pub sinks: SinksConfig,
+    pub etl: EtlConfig,
+    pub dlq_topic: String,
+    pub consumer_group: String,
+    pub source_topics: Vec<String>,
+}
+
+impl Default for PipelineConfig {
+    fn default() -> Self {
+        Self {
+            kafka: KafkaConfig::default(),
+            sinks: SinksConfig::default(),
+            etl: EtlConfig::default(),
+            dlq_topic: "stellar.dlq".into(),
+            consumer_group: "stellar-pipeline".into(),
+            source_topics: vec!["stellar.ledger.events".into()],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KafkaConfig {
+    pub brokers: String,
+    pub security_protocol: String,
+    pub sasl_mechanism: Option<String>,
+    pub sasl_username: Option<String>,
+    pub sasl_password: Option<String>,
+    /// Max messages to buffer before back-pressure
+    pub fetch_max_bytes: usize,
+}
+
+impl Default for KafkaConfig {
+    fn default() -> Self {
+        Self {
+            brokers: "localhost:9092".into(),
+            security_protocol: "PLAINTEXT".into(),
+            sasl_mechanism: None,
+            sasl_username: None,
+            sasl_password: None,
+            fetch_max_bytes: 52_428_800,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SinksConfig {
+    pub postgres: Option<PostgresSinkConfig>,
+    pub elasticsearch: Option<ElasticsearchSinkConfig>,
+    pub s3: Option<S3SinkConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PostgresSinkConfig {
+    pub database_url: String,
+    pub table: String,
+    pub batch_size: usize,
+}
+
+impl Default for PostgresSinkConfig {
+    fn default() -> Self {
+        Self {
+            database_url: "postgres://localhost/stellar".into(),
+            table: "ledger_events".into(),
+            batch_size: 500,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ElasticsearchSinkConfig {
+    pub url: String,
+    pub index: String,
+    pub batch_size: usize,
+}
+
+impl Default for ElasticsearchSinkConfig {
+    fn default() -> Self {
+        Self {
+            url: "http://localhost:9200".into(),
+            index: "stellar-ledger".into(),
+            batch_size: 500,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct S3SinkConfig {
+    pub bucket: String,
+    pub prefix: String,
+    pub region: String,
+    /// Flush to S3 after this many records
+    pub batch_size: usize,
+}
+
+impl Default for S3SinkConfig {
+    fn default() -> Self {
+        Self {
+            bucket: "stellar-pipeline".into(),
+            prefix: "ledger-events/".into(),
+            region: "us-east-1".into(),
+            batch_size: 1000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EtlConfig {
+    /// Drop records that fail schema validation instead of sending to DLQ
+    pub drop_invalid: bool,
+    /// Enrich records with pipeline metadata fields
+    pub add_pipeline_metadata: bool,
+}
+
+impl Default for EtlConfig {
+    fn default() -> Self {
+        Self {
+            drop_invalid: false,
+            add_pipeline_metadata: true,
+        }
+    }
+}

--- a/src/data_pipeline/etl.rs
+++ b/src/data_pipeline/etl.rs
@@ -1,0 +1,156 @@
+//! ETL transformations, schema validation, and data quality checks.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use thiserror::Error;
+
+/// A record flowing through the pipeline after ETL.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EtlRecord {
+    /// Unique record ID (Kafka topic + partition + offset)
+    pub id: String,
+    /// Source Kafka topic
+    pub source_topic: String,
+    /// Kafka partition
+    pub partition: i32,
+    /// Kafka offset
+    pub offset: i64,
+    /// Transformed payload
+    pub payload: Value,
+    /// Pipeline metadata injected during ETL
+    pub metadata: HashMap<String, String>,
+    /// ISO-8601 timestamp when the record entered the pipeline
+    pub pipeline_ts: String,
+    /// Ledger sequence number extracted from payload (if present)
+    pub ledger_seq: Option<u64>,
+}
+
+#[derive(Debug, Error)]
+pub enum TransformError {
+    #[error("schema validation failed: {0}")]
+    SchemaValidation(String),
+    #[error("data quality check failed: {field} — {reason}")]
+    DataQuality { field: String, reason: String },
+    #[error("transform error: {0}")]
+    Transform(String),
+}
+
+/// Validates and transforms a raw Kafka message payload.
+pub struct EtlTransformer {
+    add_metadata: bool,
+}
+
+impl EtlTransformer {
+    pub fn new(add_metadata: bool) -> Self {
+        Self { add_metadata }
+    }
+
+    /// Transform raw bytes from Kafka into an [`EtlRecord`].
+    pub fn transform(
+        &self,
+        raw: &[u8],
+        topic: &str,
+        partition: i32,
+        offset: i64,
+    ) -> Result<EtlRecord, TransformError> {
+        // Parse JSON payload
+        let mut payload: Value = serde_json::from_slice(raw)
+            .map_err(|e| TransformError::SchemaValidation(e.to_string()))?;
+
+        // Schema validation: require top-level object
+        if !payload.is_object() {
+            return Err(TransformError::SchemaValidation(
+                "payload must be a JSON object".into(),
+            ));
+        }
+
+        // Data quality checks
+        Self::check_quality(&payload)?;
+
+        // Normalize: ensure event_type field exists
+        if payload.get("event_type").is_none() {
+            payload["event_type"] = Value::String("unknown".into());
+        }
+
+        // Extract ledger sequence if present
+        let ledger_seq = payload
+            .get("ledger_sequence")
+            .or_else(|| payload.get("ledger_seq"))
+            .and_then(Value::as_u64);
+
+        let mut metadata = HashMap::new();
+        if self.add_metadata {
+            metadata.insert("pipeline_version".into(), env!("CARGO_PKG_VERSION").into());
+            metadata.insert("source_topic".into(), topic.into());
+            metadata.insert("partition".into(), partition.to_string());
+            metadata.insert("offset".into(), offset.to_string());
+        }
+
+        Ok(EtlRecord {
+            id: format!("{topic}:{partition}:{offset}"),
+            source_topic: topic.into(),
+            partition,
+            offset,
+            payload,
+            metadata,
+            pipeline_ts: Utc::now().to_rfc3339(),
+            ledger_seq,
+        })
+    }
+
+    fn check_quality(payload: &Value) -> Result<(), TransformError> {
+        let obj = payload.as_object().unwrap(); // already validated above
+
+        // Ledger sequence must be a non-negative integer if present
+        if let Some(seq) = obj.get("ledger_sequence").or_else(|| obj.get("ledger_seq")) {
+            if seq.as_u64().is_none() {
+                return Err(TransformError::DataQuality {
+                    field: "ledger_sequence".into(),
+                    reason: "must be a non-negative integer".into(),
+                });
+            }
+        }
+
+        // Timestamp field must be parseable if present
+        if let Some(ts) = obj.get("timestamp").and_then(Value::as_str) {
+            if chrono::DateTime::parse_from_rfc3339(ts).is_err() {
+                return Err(TransformError::DataQuality {
+                    field: "timestamp".into(),
+                    reason: "must be RFC-3339 formatted".into(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transform_valid_record() {
+        let t = EtlTransformer::new(true);
+        let raw = br#"{"ledger_sequence": 42, "event_type": "transaction"}"#;
+        let rec = t.transform(raw, "stellar.ledger.events", 0, 100).unwrap();
+        assert_eq!(rec.ledger_seq, Some(42));
+        assert_eq!(rec.offset, 100);
+    }
+
+    #[test]
+    fn transform_invalid_json() {
+        let t = EtlTransformer::new(false);
+        assert!(t.transform(b"not json", "topic", 0, 0).is_err());
+    }
+
+    #[test]
+    fn transform_bad_ledger_seq() {
+        let t = EtlTransformer::new(false);
+        let raw = br#"{"ledger_sequence": -1}"#;
+        // -1 is not a valid u64, but serde_json parses it as i64 so as_u64() returns None
+        assert!(t.transform(raw, "topic", 0, 0).is_err());
+    }
+}

--- a/src/data_pipeline/lineage.rs
+++ b/src/data_pipeline/lineage.rs
@@ -1,0 +1,117 @@
+//! Data lineage tracking and audit trail for the pipeline.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::debug;
+
+/// A single lineage event recorded as a record moves through the pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LineageEvent {
+    pub record_id: String,
+    pub stage: String,
+    pub status: LineageStatus,
+    pub timestamp: String,
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LineageStatus {
+    Received,
+    Transformed,
+    ValidationFailed,
+    SinkSuccess,
+    SinkFailed,
+    DeadLettered,
+}
+
+/// Thread-safe lineage tracker that stores an in-memory audit trail.
+///
+/// In production this would be persisted to a database or shipped to an
+/// audit log service; the in-memory ring buffer here is sufficient for
+/// operator-level observability.
+#[derive(Clone)]
+pub struct LineageTracker {
+    /// Capped ring buffer — keeps the last `capacity` events.
+    events: Arc<RwLock<Vec<LineageEvent>>>,
+    capacity: usize,
+}
+
+impl LineageTracker {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            events: Arc::new(RwLock::new(Vec::with_capacity(capacity))),
+            capacity,
+        }
+    }
+
+    /// Record a lineage event for `record_id` at `stage`.
+    pub async fn record(
+        &self,
+        record_id: impl Into<String>,
+        stage: impl Into<String>,
+        status: LineageStatus,
+        detail: Option<String>,
+    ) {
+        let event = LineageEvent {
+            record_id: record_id.into(),
+            stage: stage.into(),
+            status,
+            timestamp: Utc::now().to_rfc3339(),
+            detail,
+        };
+        debug!(record_id = %event.record_id, stage = %event.stage, "lineage event");
+        let mut guard = self.events.write().await;
+        if guard.len() >= self.capacity {
+            guard.remove(0);
+        }
+        guard.push(event);
+    }
+
+    /// Return a snapshot of all stored lineage events.
+    pub async fn snapshot(&self) -> Vec<LineageEvent> {
+        self.events.read().await.clone()
+    }
+
+    /// Return lineage events for a specific record ID.
+    pub async fn for_record(&self, record_id: &str) -> Vec<LineageEvent> {
+        self.events
+            .read()
+            .await
+            .iter()
+            .filter(|e| e.record_id == record_id)
+            .cloned()
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn records_and_retrieves_events() {
+        let tracker = LineageTracker::new(100);
+        tracker
+            .record("rec-1", "etl", LineageStatus::Transformed, None)
+            .await;
+        tracker
+            .record("rec-1", "postgres_sink", LineageStatus::SinkSuccess, None)
+            .await;
+        let events = tracker.for_record("rec-1").await;
+        assert_eq!(events.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn respects_capacity() {
+        let tracker = LineageTracker::new(3);
+        for i in 0..5u32 {
+            tracker
+                .record(format!("rec-{i}"), "etl", LineageStatus::Received, None)
+                .await;
+        }
+        assert_eq!(tracker.snapshot().await.len(), 3);
+    }
+}

--- a/src/data_pipeline/metrics.rs
+++ b/src/data_pipeline/metrics.rs
@@ -1,0 +1,95 @@
+//! Pipeline throughput, latency, and error metrics.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+/// Shared pipeline metrics counters.
+#[derive(Clone, Default)]
+pub struct PipelineMetrics {
+    inner: Arc<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    records_received: AtomicU64,
+    records_transformed: AtomicU64,
+    records_dlq: AtomicU64,
+    transform_errors: AtomicU64,
+    sink_successes: AtomicU64,
+    sink_errors: AtomicU64,
+    /// Cumulative processing latency in microseconds (for mean calculation)
+    latency_us_total: AtomicU64,
+    latency_samples: AtomicU64,
+}
+
+impl PipelineMetrics {
+    pub fn record_received(&self) {
+        self.inner.records_received.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_transformed(&self) {
+        self.inner
+            .records_transformed
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_dlq(&self) {
+        self.inner.records_dlq.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_transform_error(&self) {
+        self.inner
+            .transform_errors
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_sink_success(&self) {
+        self.inner.sink_successes.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_sink_error(&self) {
+        self.inner.sink_errors.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_latency(&self, start: Instant) {
+        let us = start.elapsed().as_micros() as u64;
+        self.inner
+            .latency_us_total
+            .fetch_add(us, Ordering::Relaxed);
+        self.inner
+            .latency_samples
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn snapshot(&self) -> MetricsSnapshot {
+        let samples = self.inner.latency_samples.load(Ordering::Relaxed);
+        let mean_latency_us = if samples > 0 {
+            self.inner.latency_us_total.load(Ordering::Relaxed) / samples
+        } else {
+            0
+        };
+        MetricsSnapshot {
+            records_received: self.inner.records_received.load(Ordering::Relaxed),
+            records_transformed: self.inner.records_transformed.load(Ordering::Relaxed),
+            records_dlq: self.inner.records_dlq.load(Ordering::Relaxed),
+            transform_errors: self.inner.transform_errors.load(Ordering::Relaxed),
+            sink_successes: self.inner.sink_successes.load(Ordering::Relaxed),
+            sink_errors: self.inner.sink_errors.load(Ordering::Relaxed),
+            mean_latency_us,
+        }
+    }
+}
+
+/// Point-in-time snapshot of pipeline metrics.
+#[derive(Debug, Clone)]
+pub struct MetricsSnapshot {
+    pub records_received: u64,
+    pub records_transformed: u64,
+    pub records_dlq: u64,
+    pub transform_errors: u64,
+    pub sink_successes: u64,
+    pub sink_errors: u64,
+    /// Mean end-to-end processing latency in microseconds
+    pub mean_latency_us: u64,
+}

--- a/src/data_pipeline/mod.rs
+++ b/src/data_pipeline/mod.rs
@@ -1,0 +1,34 @@
+//! Data pipeline for Stellar ledger stream processing and ETL (#788).
+//!
+//! Architecture:
+//! ```
+//! Kafka Source → ETL Transform → Schema Validation → Multi-Sink Fan-out
+//!                                                   ├─ PostgreSQL
+//!                                                   ├─ Elasticsearch
+//!                                                   └─ S3
+//!                     ↓ on error
+//!                Dead Letter Queue (Kafka DLQ topic)
+//! ```
+//!
+//! Features:
+//! - Kafka-based event streaming with consumer groups
+//! - Real-time ETL transformations with schema validation
+//! - Data quality checks
+//! - Multiple sink connectors (PostgreSQL, Elasticsearch, S3)
+//! - Data lineage tracking and audit trail
+//! - Pipeline monitoring (throughput, latency, error metrics)
+//! - Dead letter queue for failed records
+
+pub mod config;
+pub mod etl;
+pub mod lineage;
+pub mod metrics;
+pub mod pipeline;
+pub mod sinks;
+
+pub use config::PipelineConfig;
+pub use pipeline::{DataPipeline, PipelineHandle};
+pub use etl::{EtlRecord, TransformError};
+pub use lineage::LineageTracker;
+pub use metrics::PipelineMetrics;
+pub use sinks::SinkError;

--- a/src/data_pipeline/pipeline.rs
+++ b/src/data_pipeline/pipeline.rs
@@ -1,0 +1,248 @@
+//! Main pipeline orchestration: Kafka consumer → ETL → multi-sink fan-out with DLQ.
+
+use crate::data_pipeline::{
+    config::PipelineConfig,
+    etl::EtlTransformer,
+    lineage::{LineageStatus, LineageTracker},
+    metrics::PipelineMetrics,
+    sinks::{build_sinks, Sink, SinkError},
+};
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::watch;
+use tracing::{error, info, warn};
+
+/// Handle returned by [`DataPipeline::start`] for monitoring and shutdown.
+pub struct PipelineHandle {
+    pub metrics: PipelineMetrics,
+    pub lineage: LineageTracker,
+    shutdown_tx: watch::Sender<bool>,
+}
+
+impl PipelineHandle {
+    /// Signal the pipeline to stop consuming.
+    pub fn shutdown(&self) {
+        let _ = self.shutdown_tx.send(true);
+    }
+}
+
+/// The data pipeline.
+pub struct DataPipeline {
+    config: PipelineConfig,
+}
+
+impl DataPipeline {
+    pub fn new(config: PipelineConfig) -> Self {
+        Self { config }
+    }
+
+    /// Start the pipeline.  Returns a [`PipelineHandle`] immediately; the
+    /// pipeline runs in a background Tokio task.
+    ///
+    /// When the `kafka` feature is disabled the pipeline runs in a no-op mode
+    /// that is still useful for testing the ETL and sink layers.
+    pub async fn start(self) -> Result<PipelineHandle, crate::error::Error> {
+        let metrics = PipelineMetrics::default();
+        let lineage = LineageTracker::new(10_000);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let handle = PipelineHandle {
+            metrics: metrics.clone(),
+            lineage: lineage.clone(),
+            shutdown_tx,
+        };
+
+        let config = Arc::new(self.config);
+        let sinks = build_sinks(&config.sinks)
+            .await
+            .map_err(|e| crate::error::Error::ConfigError(e.to_string()))?;
+        let sinks: Arc<Vec<Box<dyn Sink>>> = Arc::new(sinks);
+
+        tokio::spawn(run_pipeline(
+            config,
+            sinks,
+            metrics,
+            lineage,
+            shutdown_rx,
+        ));
+
+        Ok(handle)
+    }
+}
+
+async fn run_pipeline(
+    config: Arc<PipelineConfig>,
+    sinks: Arc<Vec<Box<dyn Sink>>>,
+    metrics: PipelineMetrics,
+    lineage: LineageTracker,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    #[cfg(feature = "kafka")]
+    {
+        run_kafka_pipeline(config, sinks, metrics, lineage, shutdown_rx).await;
+    }
+    #[cfg(not(feature = "kafka"))]
+    {
+        info!("data pipeline started in no-op mode (kafka feature not enabled)");
+        let _ = shutdown_rx.changed().await;
+        info!("data pipeline stopped");
+    }
+}
+
+#[cfg(feature = "kafka")]
+async fn run_kafka_pipeline(
+    config: Arc<PipelineConfig>,
+    sinks: Arc<Vec<Box<dyn Sink>>>,
+    metrics: PipelineMetrics,
+    lineage: LineageTracker,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    use rdkafka::consumer::{Consumer, StreamConsumer};
+    use rdkafka::message::Message as KafkaMessage;
+    use rdkafka::producer::{FutureProducer, FutureRecord};
+    use rdkafka::ClientConfig;
+    use std::time::Duration;
+
+    let mut client_config = ClientConfig::new();
+    client_config
+        .set("bootstrap.servers", &config.kafka.brokers)
+        .set("group.id", &config.consumer_group)
+        .set("security.protocol", &config.kafka.security_protocol)
+        .set("enable.auto.commit", "true")
+        .set("auto.offset.reset", "earliest");
+
+    if let (Some(mech), Some(user), Some(pass)) = (
+        &config.kafka.sasl_mechanism,
+        &config.kafka.sasl_username,
+        &config.kafka.sasl_password,
+    ) {
+        client_config
+            .set("sasl.mechanism", mech)
+            .set("sasl.username", user)
+            .set("sasl.password", pass);
+    }
+
+    let consumer: StreamConsumer = match client_config.create() {
+        Ok(c) => c,
+        Err(e) => {
+            error!("failed to create Kafka consumer: {e}");
+            return;
+        }
+    };
+
+    let topics: Vec<&str> = config.source_topics.iter().map(String::as_str).collect();
+    if let Err(e) = consumer.subscribe(&topics) {
+        error!("failed to subscribe to topics: {e}");
+        return;
+    }
+
+    // DLQ producer
+    let dlq_producer: FutureProducer = match client_config.create() {
+        Ok(p) => p,
+        Err(e) => {
+            error!("failed to create DLQ producer: {e}");
+            return;
+        }
+    };
+
+    let transformer = EtlTransformer::new(config.etl.add_pipeline_metadata);
+    info!(topics = ?config.source_topics, "data pipeline consuming");
+
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.changed() => {
+                info!("data pipeline shutting down");
+                break;
+            }
+            msg = consumer.recv() => {
+                match msg {
+                    Err(e) => {
+                        warn!("kafka receive error: {e}");
+                    }
+                    Ok(m) => {
+                        let start = Instant::now();
+                        metrics.record_received();
+
+                        let topic = m.topic().to_string();
+                        let partition = m.partition();
+                        let offset = m.offset();
+                        let record_id = format!("{topic}:{partition}:{offset}");
+
+                        lineage.record(&record_id, "kafka_source", LineageStatus::Received, None).await;
+
+                        let payload = match m.payload() {
+                            Some(p) => p,
+                            None => {
+                                warn!(%record_id, "empty kafka message payload");
+                                continue;
+                            }
+                        };
+
+                        // ETL transform
+                        let etl_record = match transformer.transform(payload, &topic, partition, offset) {
+                            Ok(r) => {
+                                metrics.record_transformed();
+                                lineage.record(&record_id, "etl", LineageStatus::Transformed, None).await;
+                                r
+                            }
+                            Err(e) => {
+                                metrics.record_transform_error();
+                                lineage.record(&record_id, "etl", LineageStatus::ValidationFailed, Some(e.to_string())).await;
+                                if !config.etl.drop_invalid {
+                                    send_to_dlq(&dlq_producer, &config.dlq_topic, payload, &record_id, &e.to_string()).await;
+                                    metrics.record_dlq();
+                                    lineage.record(&record_id, "dlq", LineageStatus::DeadLettered, None).await;
+                                }
+                                continue;
+                            }
+                        };
+
+                        // Fan-out to all sinks
+                        let batch = std::slice::from_ref(&etl_record);
+                        for sink in sinks.iter() {
+                            match sink.write_batch(batch).await {
+                                Ok(_) => {
+                                    metrics.record_sink_success();
+                                    lineage.record(&record_id, sink.name(), LineageStatus::SinkSuccess, None).await;
+                                }
+                                Err(e) => {
+                                    metrics.record_sink_error();
+                                    lineage.record(&record_id, sink.name(), LineageStatus::SinkFailed, Some(e.to_string())).await;
+                                    error!(sink = sink.name(), %record_id, error = %e, "sink write failed");
+                                    // Send to DLQ on sink failure
+                                    send_to_dlq(&dlq_producer, &config.dlq_topic, payload, &record_id, &e.to_string()).await;
+                                    metrics.record_dlq();
+                                }
+                            }
+                        }
+
+                        metrics.record_latency(start);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "kafka")]
+async fn send_to_dlq(
+    producer: &rdkafka::producer::FutureProducer,
+    dlq_topic: &str,
+    payload: &[u8],
+    record_id: &str,
+    reason: &str,
+) {
+    use rdkafka::producer::FutureRecord;
+    use std::time::Duration;
+
+    let record = FutureRecord::to(dlq_topic)
+        .key(record_id)
+        .payload(payload)
+        .headers(
+            rdkafka::message::OwnedHeaders::new()
+                .insert(rdkafka::message::Header { key: "dlq_reason", value: Some(reason) }),
+        );
+    if let Err((e, _)) = producer.send(record, Duration::from_secs(5)).await {
+        error!(dlq_topic, record_id, error = %e, "failed to send to DLQ");
+    }
+}

--- a/src/data_pipeline/sinks.rs
+++ b/src/data_pipeline/sinks.rs
@@ -1,0 +1,255 @@
+//! Multi-sink connectors: PostgreSQL, Elasticsearch, and S3.
+
+use crate::data_pipeline::{config::SinksConfig, etl::EtlRecord};
+use async_trait::async_trait;
+use thiserror::Error;
+use tracing::{info, warn};
+
+#[derive(Debug, Error)]
+pub enum SinkError {
+    #[error("postgres sink error: {0}")]
+    Postgres(String),
+    #[error("elasticsearch sink error: {0}")]
+    Elasticsearch(String),
+    #[error("s3 sink error: {0}")]
+    S3(String),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+/// Common interface for all pipeline sinks.
+#[async_trait]
+pub trait Sink: Send + Sync {
+    async fn write_batch(&self, records: &[EtlRecord]) -> Result<usize, SinkError>;
+    fn name(&self) -> &str;
+}
+
+// ── PostgreSQL Sink ───────────────────────────────────────────────────────────
+
+pub struct PostgresSink {
+    pool: sqlx::PgPool,
+    table: String,
+    batch_size: usize,
+}
+
+impl PostgresSink {
+    pub async fn new(
+        database_url: &str,
+        table: impl Into<String>,
+        batch_size: usize,
+    ) -> Result<Self, SinkError> {
+        let pool = sqlx::PgPool::connect(database_url)
+            .await
+            .map_err(|e| SinkError::Postgres(e.to_string()))?;
+        Ok(Self {
+            pool,
+            table: table.into(),
+            batch_size,
+        })
+    }
+}
+
+#[async_trait]
+impl Sink for PostgresSink {
+    fn name(&self) -> &str {
+        "postgres"
+    }
+
+    async fn write_batch(&self, records: &[EtlRecord]) -> Result<usize, SinkError> {
+        let mut written = 0;
+        for chunk in records.chunks(self.batch_size) {
+            let mut tx = self
+                .pool
+                .begin()
+                .await
+                .map_err(|e| SinkError::Postgres(e.to_string()))?;
+            for rec in chunk {
+                let payload = serde_json::to_string(&rec.payload)?;
+                sqlx::query(&format!(
+                    "INSERT INTO {} (record_id, source_topic, partition, offset_val, payload, pipeline_ts, ledger_seq) \
+                     VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7) ON CONFLICT (record_id) DO NOTHING",
+                    self.table
+                ))
+                .bind(&rec.id)
+                .bind(&rec.source_topic)
+                .bind(rec.partition)
+                .bind(rec.offset)
+                .bind(&payload)
+                .bind(&rec.pipeline_ts)
+                .bind(rec.ledger_seq.map(|s| s as i64))
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| SinkError::Postgres(e.to_string()))?;
+                written += 1;
+            }
+            tx.commit()
+                .await
+                .map_err(|e| SinkError::Postgres(e.to_string()))?;
+        }
+        info!(sink = "postgres", written, "batch written");
+        Ok(written)
+    }
+}
+
+// ── Elasticsearch Sink ────────────────────────────────────────────────────────
+
+pub struct ElasticsearchSink {
+    client: reqwest::Client,
+    url: String,
+    index: String,
+    batch_size: usize,
+}
+
+impl ElasticsearchSink {
+    pub fn new(url: impl Into<String>, index: impl Into<String>, batch_size: usize) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            url: url.into(),
+            index: index.into(),
+            batch_size,
+        }
+    }
+
+    /// Build an Elasticsearch bulk request body.
+    fn build_bulk_body(records: &[EtlRecord]) -> Result<String, SinkError> {
+        let mut body = String::new();
+        for rec in records {
+            let meta = serde_json::json!({ "index": { "_id": rec.id } });
+            body.push_str(&serde_json::to_string(&meta)?);
+            body.push('\n');
+            body.push_str(&serde_json::to_string(rec)?);
+            body.push('\n');
+        }
+        Ok(body)
+    }
+}
+
+#[async_trait]
+impl Sink for ElasticsearchSink {
+    fn name(&self) -> &str {
+        "elasticsearch"
+    }
+
+    async fn write_batch(&self, records: &[EtlRecord]) -> Result<usize, SinkError> {
+        let mut written = 0;
+        for chunk in records.chunks(self.batch_size) {
+            let body = Self::build_bulk_body(chunk)?;
+            let resp = self
+                .client
+                .post(format!("{}/_bulk", self.url))
+                .header("Content-Type", "application/x-ndjson")
+                .body(body)
+                .send()
+                .await
+                .map_err(|e| SinkError::Elasticsearch(e.to_string()))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                return Err(SinkError::Elasticsearch(format!("{status}: {text}")));
+            }
+            written += chunk.len();
+        }
+        info!(sink = "elasticsearch", written, "batch written");
+        Ok(written)
+    }
+}
+
+// ── S3 Sink ───────────────────────────────────────────────────────────────────
+
+pub struct S3Sink {
+    client: aws_sdk_s3::Client,
+    bucket: String,
+    prefix: String,
+    batch_size: usize,
+}
+
+impl S3Sink {
+    pub async fn new(
+        bucket: impl Into<String>,
+        prefix: impl Into<String>,
+        region: &str,
+        batch_size: usize,
+    ) -> Self {
+        let config = aws_config::from_env()
+            .region(aws_config::meta::region::RegionProviderChain::first_try(
+                aws_sdk_s3::config::Region::new(region.to_string()),
+            ))
+            .load()
+            .await;
+        Self {
+            client: aws_sdk_s3::Client::new(&config),
+            bucket: bucket.into(),
+            prefix: prefix.into(),
+            batch_size,
+        }
+    }
+}
+
+#[async_trait]
+impl Sink for S3Sink {
+    fn name(&self) -> &str {
+        "s3"
+    }
+
+    async fn write_batch(&self, records: &[EtlRecord]) -> Result<usize, SinkError> {
+        let mut written = 0;
+        for chunk in records.chunks(self.batch_size) {
+            // Serialize chunk as newline-delimited JSON
+            let mut body = String::new();
+            for rec in chunk {
+                body.push_str(&serde_json::to_string(rec)?);
+                body.push('\n');
+            }
+            // Key: prefix/YYYY-MM-DD/first_record_id.ndjson
+            let date = chrono::Utc::now().format("%Y-%m-%d");
+            let first_id = chunk.first().map(|r| r.id.as_str()).unwrap_or("batch");
+            let key = format!("{}{}/{}.ndjson", self.prefix, date, first_id);
+            self.client
+                .put_object()
+                .bucket(&self.bucket)
+                .key(&key)
+                .body(aws_sdk_s3::primitives::ByteStream::from(
+                    body.into_bytes(),
+                ))
+                .content_type("application/x-ndjson")
+                .send()
+                .await
+                .map_err(|e| SinkError::S3(e.to_string()))?;
+            written += chunk.len();
+        }
+        info!(sink = "s3", written, "batch written");
+        Ok(written)
+    }
+}
+
+// ── Sink factory ─────────────────────────────────────────────────────────────
+
+/// Build the list of enabled sinks from configuration.
+pub async fn build_sinks(cfg: &SinksConfig) -> Result<Vec<Box<dyn Sink>>, SinkError> {
+    let mut sinks: Vec<Box<dyn Sink>> = Vec::new();
+
+    if let Some(pg) = &cfg.postgres {
+        let sink = PostgresSink::new(&pg.database_url, &pg.table, pg.batch_size).await?;
+        sinks.push(Box::new(sink));
+    }
+
+    if let Some(es) = &cfg.elasticsearch {
+        sinks.push(Box::new(ElasticsearchSink::new(
+            &es.url,
+            &es.index,
+            es.batch_size,
+        )));
+    }
+
+    if let Some(s3) = &cfg.s3 {
+        sinks.push(Box::new(
+            S3Sink::new(&s3.bucket, &s3.prefix, &s3.region, s3.batch_size).await,
+        ));
+    }
+
+    if sinks.is_empty() {
+        warn!("no sinks configured — records will be consumed but not stored");
+    }
+
+    Ok(sinks)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,9 @@
 //!     enableHistoryArchive: true
 //! ```
 
+pub mod api_gateway;
 pub mod backup;
+pub mod data_pipeline;
 pub mod deployment_strategy;
 pub mod load_balancer;
 pub mod message_queue;


### PR DESCRIPTION
summaryy

Closes #788 
Closes #789 
Closes  #708 

#708 — Horizon Grafana Dashboard
- `monitoring/grafana-horizon.json`: 10-panel dashboard (HTTP request rate, error rate, ledger lag, latency p50/p95/p99, heatmap, DB pool, DB query duration, DB errors, ingestion throughput)
- `docs/horizon-dashboard.md`: import instructions (UI, API, Helm), required metrics, alerting rules

### #788 — Data Pipeline
- `src/data_pipeline/`: Kafka consumer (gated on `kafka` feature), ETL with schema validation + data quality checks, multi-sink fan-out (PostgreSQL, Elasticsearch, S3), dead letter queue, lineage tracker, pipeline metrics

### #789 — API Gateway
- `src/api_gateway/`: SHA-256 API key auth, token-bucket rate limiting, longest-prefix intelligent router with header predicates, protocol transformation (REST/gRPC/GraphQL), version deprecation/sunset headers, analytics store, management endpoints (`/_gateway/keys`, `/_gateway/analytics`)