### PR TITLE
feat: add PodSecurityStandard and SecurityContext configuration to StellarNode

### DIFF
--- a/examples/security-context-baseline.yaml
+++ b/examples/security-context-baseline.yaml
@@ -1,0 +1,20 @@
+# Example: StellarNode with PSS 'baseline' security context (for legacy images that
+# require a writable root filesystem but still avoid privilege escalation).
+apiVersion: stellar.org/v1alpha1
+kind: StellarNode
+metadata:
+  name: horizon-baseline
+  namespace: stellar-staging
+spec:
+  nodeType: Horizon
+  network: Testnet
+  version: "v21.0.0"
+  securityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false   # relaxed for legacy images
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault

--- a/examples/security-context-privileged.yaml
+++ b/examples/security-context-privileged.yaml
@@ -1,0 +1,14 @@
+# Example: StellarNode with privileged security context.
+# WARNING: Only use in isolated development or test namespaces.
+# NEVER use in production. Violates PSS 'restricted' and 'baseline'.
+apiVersion: stellar.org/v1alpha1
+kind: StellarNode
+metadata:
+  name: validator-dev
+  namespace: stellar-dev
+spec:
+  nodeType: Validator
+  network: Futurenet
+  version: "v21.0.0"
+  securityContext:
+    privileged: true   # DEV ONLY — bypasses all container isolation

--- a/examples/security-context-restricted.yaml
+++ b/examples/security-context-restricted.yaml
@@ -1,0 +1,23 @@
+# Example: StellarNode with PSS 'restricted' security context (default operator behavior)
+# This matches the Kubernetes Pod Security Standards 'restricted' profile.
+apiVersion: stellar.org/v1alpha1
+kind: StellarNode
+metadata:
+  name: horizon-restricted
+  namespace: stellar-prod
+spec:
+  nodeType: Horizon
+  network: Public
+  version: "v21.0.0"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 10000
+    runAsGroup: 10000
+    fsGroup: 10000
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault

--- a/src/controller/pss.rs
+++ b/src/controller/pss.rs
@@ -15,6 +15,7 @@ use kube::api::{Api, Patch, PatchParams};
 use kube::Client;
 use tracing::{info, instrument, warn};
 
+use crate::crd::types::StellarSecurityContext;
 use crate::crd::StellarNodeSpec;
 use crate::error::{Error, Result};
 
@@ -175,6 +176,11 @@ impl PssViolation {
 pub fn validate_pss_compliance(spec: &StellarNodeSpec) -> Vec<PssViolation> {
     let mut violations = Vec::new();
 
+    // Validate spec.securityContext override field
+    if let Some(sc) = &spec.security_context {
+        violations.extend(validate_stellar_security_context(sc));
+    }
+
     // Check sidecars for privilege escalation attempts
     if let Some(sidecars) = &spec.sidecars {
         for (i, sidecar) in sidecars.iter().enumerate() {
@@ -252,3 +258,142 @@ fn check_container_security_context(
         ));
     }
 }
+
+// ── StellarNode security_context field validation ────────────────────────────
+
+/// Validate the `spec.securityContext` override field against PSS `restricted` rules.
+///
+/// Returns violations for fields that would break PSS compliance.
+pub fn validate_stellar_security_context(
+    ctx: &StellarSecurityContext,
+) -> Vec<PssViolation> {
+    let mut v = Vec::new();
+    let prefix = "spec.securityContext";
+
+    if ctx.privileged == Some(true) {
+        v.push(PssViolation::new(
+            format!("{prefix}.privileged"),
+            "privileged containers are forbidden under PSS 'restricted'",
+        ));
+    }
+    if ctx.allow_privilege_escalation == Some(true) {
+        v.push(PssViolation::new(
+            format!("{prefix}.allowPrivilegeEscalation"),
+            "allowPrivilegeEscalation must be false under PSS 'restricted'",
+        ));
+    }
+    if ctx.run_as_non_root == Some(false) {
+        v.push(PssViolation::new(
+            format!("{prefix}.runAsNonRoot"),
+            "runAsNonRoot: false is forbidden under PSS 'restricted'",
+        ));
+    }
+    if ctx.run_as_user == Some(0) {
+        v.push(PssViolation::new(
+            format!("{prefix}.runAsUser"),
+            "runAsUser 0 (root) is forbidden under PSS 'restricted'",
+        ));
+    }
+    if let Some(caps) = &ctx.capabilities {
+        let forbidden = ["NET_ADMIN", "SYS_ADMIN", "SYS_PTRACE", "NET_RAW", "SYS_MODULE"];
+        for cap in &caps.add {
+            if forbidden.contains(&cap.as_str()) {
+                v.push(PssViolation::new(
+                    format!("{prefix}.capabilities.add"),
+                    format!("capability '{cap}' is forbidden under PSS 'restricted'"),
+                ));
+            }
+        }
+    }
+    if let Some(seccomp) = &ctx.seccomp_profile {
+        if seccomp.type_ == "Unconfined" {
+            v.push(PssViolation::new(
+                format!("{prefix}.seccompProfile.type"),
+                "seccompProfile type 'Unconfined' is forbidden under PSS 'restricted'",
+            ));
+        }
+    }
+    v
+}
+
+// ── Security context merge helpers ────────────────────────────────────────────
+
+/// Build a merged [`SecurityContext`] from the operator's secure defaults plus
+/// any user-supplied [`StellarSecurityContext`] overrides.
+///
+/// Fields explicitly set in `override_ctx` take precedence; unset fields fall
+/// back to the restricted defaults.
+pub fn build_container_security_context(
+    override_ctx: Option<&StellarSecurityContext>,
+) -> SecurityContext {
+    let mut sc = restricted_container_security_context();
+
+    if let Some(oc) = override_ctx {
+        if let Some(v) = oc.run_as_non_root {
+            sc.run_as_non_root = Some(v);
+        }
+        if let Some(v) = oc.run_as_user {
+            sc.run_as_user = Some(v);
+        }
+        if let Some(v) = oc.run_as_group {
+            sc.run_as_group = Some(v);
+        }
+        if let Some(v) = oc.read_only_root_filesystem {
+            sc.read_only_root_filesystem = Some(v);
+        }
+        if let Some(v) = oc.allow_privilege_escalation {
+            sc.allow_privilege_escalation = Some(v);
+        }
+        if let Some(v) = oc.privileged {
+            sc.privileged = Some(v);
+        }
+        if let Some(caps) = &oc.capabilities {
+            sc.capabilities = Some(Capabilities {
+                add: if caps.add.is_empty() { None } else { Some(caps.add.clone()) },
+                drop: if caps.drop.is_empty() { None } else { Some(caps.drop.clone()) },
+            });
+        }
+        if let Some(seccomp) = &oc.seccomp_profile {
+            sc.seccomp_profile = Some(SeccompProfile {
+                type_: seccomp.type_.clone(),
+                localhost_profile: seccomp.localhost_profile.clone(),
+            });
+        }
+    }
+
+    sc
+}
+
+/// Build a merged [`PodSecurityContext`] from secure defaults plus overrides.
+pub fn build_pod_security_context(
+    override_ctx: Option<&StellarSecurityContext>,
+) -> PodSecurityContext {
+    let mut psc = restricted_pod_security_context();
+
+    if let Some(oc) = override_ctx {
+        if let Some(v) = oc.run_as_non_root {
+            psc.run_as_non_root = Some(v);
+        }
+        if let Some(v) = oc.run_as_user {
+            psc.run_as_user = Some(v);
+        }
+        if let Some(v) = oc.run_as_group {
+            psc.run_as_group = Some(v);
+        }
+        if let Some(v) = oc.fs_group {
+            psc.fs_group = Some(v);
+        }
+        if let Some(seccomp) = &oc.seccomp_profile {
+            psc.seccomp_profile = Some(SeccompProfile {
+                type_: seccomp.type_.clone(),
+                localhost_profile: seccomp.localhost_profile.clone(),
+            });
+        }
+    }
+
+    psc
+}
+
+#[cfg(test)]
+#[path = "pss_test.rs"]
+mod tests;

--- a/src/controller/pss_test.rs
+++ b/src/controller/pss_test.rs
@@ -1,0 +1,176 @@
+//! Unit tests for Pod Security Standard validation and security context helpers.
+
+use super::pss::*;
+use crate::crd::types::{ContainerCapabilities, SeccompProfileOverride, StellarSecurityContext};
+
+// ── validate_stellar_security_context ────────────────────────────────────────
+
+#[test]
+fn compliant_default_ctx_has_no_violations() {
+    let ctx = StellarSecurityContext {
+        run_as_non_root: Some(true),
+        allow_privilege_escalation: Some(false),
+        read_only_root_filesystem: Some(true),
+        capabilities: Some(ContainerCapabilities {
+            drop: vec!["ALL".to_string()],
+            add: vec![],
+        }),
+        seccomp_profile: Some(SeccompProfileOverride {
+            type_: "RuntimeDefault".to_string(),
+            localhost_profile: None,
+        }),
+        ..Default::default()
+    };
+    let violations = validate_stellar_security_context(&ctx);
+    assert!(violations.is_empty(), "expected no violations, got: {violations:?}");
+}
+
+#[test]
+fn privileged_true_is_a_violation() {
+    let ctx = StellarSecurityContext {
+        privileged: Some(true),
+        ..Default::default()
+    };
+    let v = validate_stellar_security_context(&ctx);
+    assert!(v.iter().any(|x| x.field.contains("privileged")));
+}
+
+#[test]
+fn allow_privilege_escalation_true_is_a_violation() {
+    let ctx = StellarSecurityContext {
+        allow_privilege_escalation: Some(true),
+        ..Default::default()
+    };
+    let v = validate_stellar_security_context(&ctx);
+    assert!(v.iter().any(|x| x.field.contains("allowPrivilegeEscalation")));
+}
+
+#[test]
+fn run_as_non_root_false_is_a_violation() {
+    let ctx = StellarSecurityContext {
+        run_as_non_root: Some(false),
+        ..Default::default()
+    };
+    let v = validate_stellar_security_context(&ctx);
+    assert!(v.iter().any(|x| x.field.contains("runAsNonRoot")));
+}
+
+#[test]
+fn run_as_user_zero_is_a_violation() {
+    let ctx = StellarSecurityContext {
+        run_as_user: Some(0),
+        ..Default::default()
+    };
+    let v = validate_stellar_security_context(&ctx);
+    assert!(v.iter().any(|x| x.field.contains("runAsUser")));
+}
+
+#[test]
+fn forbidden_capability_is_a_violation() {
+    let ctx = StellarSecurityContext {
+        capabilities: Some(ContainerCapabilities {
+            add: vec!["SYS_ADMIN".to_string()],
+            drop: vec![],
+        }),
+        ..Default::default()
+    };
+    let v = validate_stellar_security_context(&ctx);
+    assert!(v.iter().any(|x| x.message.contains("SYS_ADMIN")));
+}
+
+#[test]
+fn unconfined_seccomp_is_a_violation() {
+    let ctx = StellarSecurityContext {
+        seccomp_profile: Some(SeccompProfileOverride {
+            type_: "Unconfined".to_string(),
+            localhost_profile: None,
+        }),
+        ..Default::default()
+    };
+    let v = validate_stellar_security_context(&ctx);
+    assert!(v.iter().any(|x| x.field.contains("seccompProfile")));
+}
+
+#[test]
+fn non_forbidden_capability_add_is_allowed() {
+    let ctx = StellarSecurityContext {
+        capabilities: Some(ContainerCapabilities {
+            add: vec!["NET_BIND_SERVICE".to_string()],
+            drop: vec!["ALL".to_string()],
+        }),
+        ..Default::default()
+    };
+    let v = validate_stellar_security_context(&ctx);
+    assert!(v.is_empty(), "NET_BIND_SERVICE should be allowed");
+}
+
+// ── build_container_security_context ─────────────────────────────────────────
+
+#[test]
+fn default_container_sc_is_restricted() {
+    let sc = build_container_security_context(None);
+    assert_eq!(sc.run_as_non_root, Some(true));
+    assert_eq!(sc.allow_privilege_escalation, Some(false));
+    assert_eq!(sc.read_only_root_filesystem, Some(true));
+    assert_eq!(sc.privileged, Some(false));
+}
+
+#[test]
+fn override_read_only_root_filesystem_is_respected() {
+    let ctx = StellarSecurityContext {
+        read_only_root_filesystem: Some(false),
+        ..Default::default()
+    };
+    let sc = build_container_security_context(Some(&ctx));
+    assert_eq!(sc.read_only_root_filesystem, Some(false));
+    // Other secure defaults should still be in place
+    assert_eq!(sc.allow_privilege_escalation, Some(false));
+}
+
+#[test]
+fn override_run_as_user_is_applied() {
+    let ctx = StellarSecurityContext {
+        run_as_user: Some(65534),
+        ..Default::default()
+    };
+    let sc = build_container_security_context(Some(&ctx));
+    assert_eq!(sc.run_as_user, Some(65534));
+}
+
+// ── build_pod_security_context ────────────────────────────────────────────────
+
+#[test]
+fn default_pod_sc_sets_non_root_and_fs_group() {
+    let psc = build_pod_security_context(None);
+    assert_eq!(psc.run_as_non_root, Some(true));
+    assert_eq!(psc.fs_group, Some(10000));
+}
+
+#[test]
+fn override_fs_group_is_respected() {
+    let ctx = StellarSecurityContext {
+        fs_group: Some(1000),
+        ..Default::default()
+    };
+    let psc = build_pod_security_context(Some(&ctx));
+    assert_eq!(psc.fs_group, Some(1000));
+    assert_eq!(psc.run_as_non_root, Some(true));
+}
+
+// ── restricted helpers ────────────────────────────────────────────────────────
+
+#[test]
+fn restricted_container_sc_drops_all_capabilities() {
+    let sc = restricted_container_security_context();
+    let caps = sc.capabilities.expect("capabilities must be set");
+    let drop = caps.drop.expect("drop must be set");
+    assert!(drop.contains(&"ALL".to_string()));
+    assert!(caps.add.is_none());
+}
+
+#[test]
+fn restricted_pod_sc_has_runtime_default_seccomp() {
+    let psc = restricted_pod_security_context();
+    let seccomp = psc.seccomp_profile.expect("seccompProfile must be set");
+    assert_eq!(seccomp.type_, "RuntimeDefault");
+}

--- a/src/crd/stellar_node.rs
+++ b/src/crd/stellar_node.rs
@@ -310,6 +310,44 @@ pub struct StellarNodeSpec {
     #[schemars(with = "Option<Vec<serde_json::Value>>")]
     pub init_containers: Option<Vec<k8s_openapi::api::core::v1::Container>>,
 
+    /// Optional pod-level and container-level security context overrides.
+    ///
+    /// When unset the operator applies secure defaults compliant with the
+    /// Kubernetes Pod Security Standards `restricted` profile:
+    /// - `runAsNonRoot: true`
+    /// - `readOnlyRootFilesystem: true`
+    /// - `allowPrivilegeEscalation: false`
+    /// - `capabilities.drop: ["ALL"]`
+    /// - `seccompProfile.type: RuntimeDefault`
+    ///
+    /// # Example — restricted (default)
+    /// ```yaml
+    /// securityContext:
+    ///   runAsNonRoot: true
+    ///   readOnlyRootFilesystem: true
+    ///   allowPrivilegeEscalation: false
+    ///   capabilities:
+    ///     drop: ["ALL"]
+    ///   seccompProfile:
+    ///     type: RuntimeDefault
+    /// ```
+    ///
+    /// # Example — baseline (loosened for legacy images)
+    /// ```yaml
+    /// securityContext:
+    ///   runAsNonRoot: true
+    ///   allowPrivilegeEscalation: false
+    ///   readOnlyRootFilesystem: false
+    /// ```
+    ///
+    /// # Example — privileged (use only in dev/test namespaces)
+    /// ```yaml
+    /// securityContext:
+    ///   privileged: true
+    /// ```
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub security_context: Option<super::types::StellarSecurityContext>,
+
     /// Optional overrides for the liveness, readiness, and startup probes on the main container.
     ///
     /// When set, the specified fields replace the operator's built-in probe defaults.

--- a/src/crd/types.rs
+++ b/src/crd/types.rs
@@ -529,6 +529,75 @@ pub struct VpaConfig {
     pub container_policies: Vec<VpaContainerPolicy>,
 }
 
+// ── Security Context ─────────────────────────────────────────────────────────
+
+/// Capabilities to add/drop at the container level.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ContainerCapabilities {
+    /// Capabilities to add (avoid unless absolutely necessary under PSS baseline).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub add: Vec<String>,
+    /// Capabilities to drop. Defaults to `["ALL"]` when using restricted PSS.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub drop: Vec<String>,
+}
+
+/// Seccomp profile override for pods/containers.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SeccompProfileOverride {
+    /// `RuntimeDefault`, `Localhost`, or `Unconfined`.
+    pub type_: String,
+    /// Path relative to the kubelet seccomp profile root (only for `Localhost`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub localhost_profile: Option<String>,
+}
+
+/// Security context overrides for StellarNode pods and containers.
+///
+/// When unset the operator enforces PSS `restricted` defaults.
+/// Any field explicitly set here overrides the corresponding default.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StellarSecurityContext {
+    /// Run as non-root user. Defaults to `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_as_non_root: Option<bool>,
+
+    /// UID to run the container process as.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_as_user: Option<i64>,
+
+    /// GID to run the container process as.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_as_group: Option<i64>,
+
+    /// fsGroup for the pod's volume ownership. Defaults to `10000`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fs_group: Option<i64>,
+
+    /// Mount root filesystem read-only. Defaults to `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub read_only_root_filesystem: Option<bool>,
+
+    /// Prevent privilege escalation. Defaults to `false` (escalation blocked).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allow_privilege_escalation: Option<bool>,
+
+    /// Run as privileged. **Never enable in production.** Defaults to `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub privileged: Option<bool>,
+
+    /// Linux capabilities override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<ContainerCapabilities>,
+
+    /// Seccomp profile override. Defaults to `RuntimeDefault`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seccomp_profile: Option<SeccompProfileOverride>,
+}
+
 /// Configuration for the durable log-to-S3 sidecar.
 ///
 /// When set, the operator injects a `stellar-log-shipper` sidecar into every


### PR DESCRIPTION
Adds securityContext field to StellarNode spec with secure defaults (non-root, read-only filesystem), custom override support, PSS restricted compliance validation, security level examples, unit tests, and best practice documentation.

Closes #836