### PR TITLE
[901] Standardize Error Context Across Rust and Shell Code

### DIFF
--- a/scripts/dev-utils/test-error-diagnostics.sh
+++ b/scripts/dev-utils/test-error-diagnostics.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/lib/errors.sh step-aware diagnostics.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="${SCRIPT_DIR}/../lib/errors.sh"
+
+step_output="$(
+  # shellcheck source=../lib/errors.sh
+  source "${LIB}"
+  sk8s_step "format check" "running cargo fmt"
+)"
+
+if ! grep -q '\[format check\]' <<<"${step_output}"; then
+  echo "expected step banner in sk8s_step output" >&2
+  exit 1
+fi
+
+fail_output="$(
+  # shellcheck source=../lib/errors.sh
+  source "${LIB}"
+  SK8S_STEP="lint"
+  sk8s_fail "clippy reported errors" "Run 'make lint'"
+)" 2>&1 || true
+
+if ! grep -q 'ERROR \[lint\]: clippy reported errors' <<<"${fail_output}"; then
+  echo "expected step name in sk8s_fail output" >&2
+  exit 1
+fi
+
+if ! grep -q "Hint: Run 'make lint'" <<<"${fail_output}"; then
+  echo "expected hint in sk8s_fail output" >&2
+  exit 1
+fi
+
+echo "error diagnostics smoke test passed"

--- a/scripts/generate-api-docs.py
+++ b/scripts/generate-api-docs.py
@@ -180,7 +180,10 @@ def main():
     output_path = Path(args.output)
 
     if not crd_path.exists():
-        print(f"Error: CRD file not found: {crd_path}", file=sys.stderr)
+        print(
+            f"ERROR [load crd]: CRD file not found: {crd_path}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     crd = load_crd(crd_path)
@@ -188,11 +191,19 @@ def main():
 
     if args.check:
         if not output_path.exists():
-            print(f"Error: {output_path} does not exist. Run 'make generate-api-docs' first.")
+            print(
+                f"ERROR [check api docs]: {output_path} does not exist. "
+                "Run 'make generate-api-docs' first.",
+                file=sys.stderr,
+            )
             sys.exit(1)
         existing = output_path.read_text()
         if existing != content:
-            print(f"Error: {output_path} is out of date. Run 'make generate-api-docs' and commit.")
+            print(
+                f"ERROR [check api docs]: {output_path} is out of date. "
+                "Run 'make generate-api-docs' and commit the changes.",
+                file=sys.stderr,
+            )
             sys.exit(1)
         print(f"OK: {output_path} is up to date.")
     else:

--- a/scripts/lib/errors.sh
+++ b/scripts/lib/errors.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# scripts/lib/errors.sh
+# Shared step-aware diagnostics for shell scripts.
+#
+# Usage:
+#   source "${SCRIPT_DIR}/lib/errors.sh"
+#   sk8s_step "format check" "Running cargo fmt --all --check"
+#   sk8s_fail "Code is not formatted" "Run 'make fmt' and retry"
+#
+# Messages follow the same `[step] detail` style as Rust helpers in src/error.rs.
+
+: "${SK8S_STEP:=unknown step}"
+
+sk8s_step() {
+  SK8S_STEP="$1"
+  echo ""
+  echo "--> [${SK8S_STEP}] $2"
+}
+
+sk8s_fail() {
+  local detail="$1"
+  local hint="${2:-}"
+  echo "ERROR [${SK8S_STEP}]: ${detail}" >&2
+  if [[ -n "${hint}" ]]; then
+    echo "  Hint: ${hint}" >&2
+  fi
+  exit 1
+}
+
+sk8s_warn() {
+  local detail="$1"
+  echo "WARN [${SK8S_STEP}]: ${detail}" >&2
+}

--- a/scripts/lib/repo.sh
+++ b/scripts/lib/repo.sh
@@ -12,8 +12,8 @@ REPO="${REPO:-$_DEFAULT_REPO}"
 
 # Validate owner/name format (no slashes in either part, exactly one slash).
 if [[ ! "$REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
-  echo "ERROR: REPO='$REPO' is not a valid 'owner/name' format." >&2
-  echo "       Set REPO=owner/name or unset it to use the default ($_DEFAULT_REPO)." >&2
+  echo "ERROR [validate repo]: REPO='$REPO' is not a valid 'owner/name' format." >&2
+  echo "  Hint: Set REPO=owner/name or unset it to use the default ($_DEFAULT_REPO)." >&2
   exit 1
 fi
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 
 # Resolve the repo root regardless of where the script is called from.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/errors.sh
+source "${SCRIPT_DIR}/lib/errors.sh"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${REPO_ROOT}"
@@ -28,21 +30,15 @@ export K8S_OPENAPI_ENABLED_VERSION
 echo "==> Starting local validation (repo: ${REPO_ROOT})"
 
 # ── Step 1: Format check ─────────────────────────────────────────────────────
-echo ""
-echo "--> [1/3] Format check (cargo fmt --all --check)"
-cargo fmt --all --check || {
-  echo ""
-  echo "ERROR: Code is not formatted. Run 'make fmt' or 'cargo fmt --all' and retry."
-  exit 1
-}
+sk8s_step "format check" "Running cargo fmt --all --check"
+if ! cargo fmt --all --check; then
+  sk8s_fail "Code is not formatted" "Run 'make fmt' or 'cargo fmt --all' and retry."
+fi
 echo "    Format OK"
 
 # ── Step 2: Lint ─────────────────────────────────────────────────────────────
-# Use exactly the same flags as the Makefile `lint` target so local and CI
-# behaviour are identical.
-echo ""
-echo "--> [2/3] Lint (cargo clippy)"
-cargo clippy --workspace --all-targets --all-features -- \
+sk8s_step "lint" "Running cargo clippy with CI flags"
+if ! cargo clippy --workspace --all-targets --all-features -- \
   -D clippy::correctness \
   -D clippy::suspicious \
   -D clippy::perf \
@@ -57,13 +53,16 @@ cargo clippy --workspace --all-targets --all-features -- \
   -A clippy::redundant_closure \
   -A clippy::items_after_test_module \
   -A clippy::approx_constant \
-  -A clippy::should_implement_trait
+  -A clippy::should_implement_trait; then
+  sk8s_fail "Clippy reported errors" "Run 'make lint' for the full output."
+fi
 echo "    Lint OK"
 
 # ── Step 3: Compile check ────────────────────────────────────────────────────
-echo ""
-echo "--> [3/3] Compile check (cargo test --no-run)"
-cargo test --workspace --no-run
+sk8s_step "compile check" "Running cargo test --no-run"
+if ! cargo test --workspace --no-run; then
+  sk8s_fail "Compilation failed during test build" "Fix compiler errors and rerun 'make validate'."
+fi
 echo "    Compile check OK"
 
 echo ""

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 
 use stellar_k8s::backup::providers::{StorageProviderTrait, UploadMetadata};
 use stellar_k8s::backup::*;
+use stellar_k8s::error::diagnostic;
 
 #[derive(Parser, Debug)]
 pub struct BackupArgs {
@@ -94,7 +95,13 @@ pub async fn run_backup(args: BackupArgs) -> Result<()> {
 
     // Validate source exists
     if !args.source.exists() {
-        return Err(anyhow::anyhow!("Source path does not exist"));
+        return Err(anyhow::anyhow!(
+            "{}",
+            diagnostic(
+                "validate source",
+                format!("path does not exist: {}", args.source.display())
+            )
+        ));
     }
 
     // Collect files to backup
@@ -121,7 +128,18 @@ pub async fn run_backup(args: BackupArgs) -> Result<()> {
         "arweave" => backup_to_arweave(&args, &metadata, &files).await?,
         "ipfs" => backup_to_ipfs(&args, &metadata, &files).await?,
         "filecoin" => backup_to_filecoin(&args, &metadata, &files).await?,
-        _ => return Err(anyhow::anyhow!("Unsupported backend: {}", args.backend)),
+        _ => {
+            return Err(anyhow::anyhow!(
+                "{}",
+                diagnostic(
+                    "select backend",
+                    format!(
+                        "unsupported backend {:?}; expected file, s3, arweave, ipfs, or filecoin",
+                        args.backend
+                    )
+                )
+            ))
+        }
     }
 
     println!("Backup completed in {:?}", start.elapsed());
@@ -149,7 +167,18 @@ pub async fn run_restore(args: RestoreArgs) -> Result<()> {
         "arweave" => restore_from_arweave(&args).await?,
         "ipfs" => restore_from_ipfs(&args).await?,
         "filecoin" => restore_from_filecoin(&args).await?,
-        _ => return Err(anyhow::anyhow!("Unsupported backend: {}", args.backend)),
+        _ => {
+            return Err(anyhow::anyhow!(
+                "{}",
+                diagnostic(
+                    "select backend",
+                    format!(
+                        "unsupported backend {:?}; expected file, s3, arweave, ipfs, or filecoin",
+                        args.backend
+                    )
+                )
+            ))
+        }
     }
 
     println!("Restore completed in {:?}", start.elapsed());
@@ -167,7 +196,18 @@ pub async fn run_list(args: ListArgs) -> Result<()> {
         "arweave" => list_from_arweave(&args).await?,
         "ipfs" => list_from_ipfs(&args).await?,
         "filecoin" => list_from_filecoin(&args).await?,
-        _ => return Err(anyhow::anyhow!("Unsupported backend: {}", args.backend)),
+        _ => {
+            return Err(anyhow::anyhow!(
+                "{}",
+                diagnostic(
+                    "select backend",
+                    format!(
+                        "unsupported backend {:?}; expected file, s3, arweave, ipfs, or filecoin",
+                        args.backend
+                    )
+                )
+            ))
+        }
     }
 
     Ok(())
@@ -186,7 +226,18 @@ pub async fn run_cleanup(args: CleanupArgs) -> Result<()> {
         "arweave" => cleanup_from_arweave(&args).await?,
         "ipfs" => cleanup_from_ipfs(&args).await?,
         "filecoin" => cleanup_from_filecoin(&args).await?,
-        _ => return Err(anyhow::anyhow!("Unsupported backend: {}", args.backend)),
+        _ => {
+            return Err(anyhow::anyhow!(
+                "{}",
+                diagnostic(
+                    "select backend",
+                    format!(
+                        "unsupported backend {:?}; expected file, s3, arweave, ipfs, or filecoin",
+                        args.backend
+                    )
+                )
+            ))
+        }
     }
 
     Ok(())
@@ -254,7 +305,13 @@ async fn restore_from_file(args: &RestoreArgs) -> Result<()> {
     let backup_path = PathBuf::from(&args.backup);
 
     if !backup_path.exists() {
-        return Err(anyhow::anyhow!("Backup file not found"));
+        return Err(anyhow::anyhow!(
+            "{}",
+            diagnostic(
+                "open backup archive",
+                format!("backup file not found: {}", backup_path.display())
+            )
+        ));
     }
 
     // Extract tar.gz
@@ -273,7 +330,13 @@ async fn restore_from_file(args: &RestoreArgs) -> Result<()> {
 async fn list_from_file(args: &ListArgs) -> Result<()> {
     let location = PathBuf::from(&args.location);
     if !location.exists() || !location.is_dir() {
-        return Err(anyhow::anyhow!("Location is not a directory"));
+        return Err(anyhow::anyhow!(
+            "{}",
+            diagnostic(
+                "list backups",
+                format!("location is not a directory: {}", location.display())
+            )
+        ));
     }
 
     let mut backups: Vec<_> = fs::read_dir(location)?
@@ -292,7 +355,13 @@ async fn list_from_file(args: &ListArgs) -> Result<()> {
 async fn cleanup_from_file(args: &CleanupArgs) -> Result<()> {
     let location = PathBuf::from(&args.location);
     if !location.exists() || !location.is_dir() {
-        return Err(anyhow::anyhow!("Location is not a directory"));
+        return Err(anyhow::anyhow!(
+            "{}",
+            diagnostic(
+                "cleanup backups",
+                format!("location is not a directory: {}", location.display())
+            )
+        ));
     }
 
     let mut backups: Vec<_> = fs::read_dir(location)?
@@ -415,4 +484,38 @@ async fn list_from_filecoin(_args: &ListArgs) -> Result<()> {
 async fn cleanup_from_filecoin(_args: &CleanupArgs) -> Result<()> {
     println!("Filecoin cleanup not fully implemented yet");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stellar_k8s::error::diagnostic;
+
+    #[test]
+    fn backup_source_missing_error_names_step() {
+        let args = BackupArgs {
+            source: PathBuf::from("/definitely/missing/stellar-backup-source"),
+            backend: "file".to_string(),
+            destination: "/tmp/out".to_string(),
+            incremental: false,
+            verify: false,
+        };
+
+        let err = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(run_backup(args))
+            .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(msg.contains("[validate source]"));
+        assert!(msg.contains("path does not exist"));
+    }
+
+    #[test]
+    fn diagnostic_format_matches_shell_style() {
+        assert_eq!(
+            diagnostic("format check", "code is not formatted"),
+            "[format check] code is not formatted"
+        );
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -112,7 +112,30 @@ pub enum Error {
 /// Result type alias for operator operations
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Format a user-facing diagnostic message with an explicit pipeline step.
+///
+/// Example: `diagnostic("load kubeconfig", "file not found at /etc/kube/config")`
+/// → `"[load kubeconfig] file not found at /etc/kube/config"`
+pub fn diagnostic(step: &str, detail: impl std::fmt::Display) -> String {
+    format!("[{step}] {detail}")
+}
+
 impl Error {
+    /// Build a configuration error that names the failing step.
+    pub fn config_step(step: &str, detail: impl std::fmt::Display) -> Self {
+        Error::ConfigError(diagnostic(step, detail))
+    }
+
+    /// Build an internal error that names the failing step.
+    pub fn internal_step(step: &str, detail: impl std::fmt::Display) -> Self {
+        Error::InternalError(diagnostic(step, detail))
+    }
+
+    /// Build a validation error that names the failing step.
+    pub fn validation_step(step: &str, detail: impl std::fmt::Display) -> Self {
+        Error::ValidationError(diagnostic(step, detail))
+    }
+
     /// Check if this error type should trigger a retry
     pub fn is_retriable(&self) -> bool {
         matches!(
@@ -168,6 +191,21 @@ impl From<kube::runtime::finalizer::Error<Error>> for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_diagnostic_includes_step_and_detail() {
+        let msg = diagnostic("validate source", "path does not exist: /tmp/data");
+        assert_eq!(msg, "[validate source] path does not exist: /tmp/data");
+    }
+
+    #[test]
+    fn test_config_step_wraps_diagnostic() {
+        let err = Error::config_step("parse db uri", "missing database name");
+        assert_eq!(
+            err.to_string(),
+            "[SK8S-004] Configuration error: [parse db uri] missing database name"
+        );
+    }
 
     #[test]
     fn test_kube_error_conversion() {

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -192,12 +192,15 @@ impl SqlExecutor {
         // postgresql://user:pass@host:5432/db
         let parts: Vec<&str> = uri.split('@').collect();
         if parts.len() != 2 {
-            return Err(Error::ConfigError("Invalid DB URI format".to_string()));
+            return Err(Error::config_step(
+                "parse db uri",
+                "expected host/database path after '@'",
+            ));
         }
 
         let host_part = parts[1];
         let slash_index = host_part.find('/').ok_or_else(|| {
-            Error::ConfigError("Invalid DB URI format (missing / after host)".to_string())
+            Error::config_step("parse db uri", "missing database path after host")
         })?;
 
         let _host_and_port = &host_part[..slash_index];


### PR DESCRIPTION
## Summary
- Add `diagnostic()` and `Error::{config,validation,internal}_step` helpers for consistent `[step] detail` messages
- Introduce `scripts/lib/errors.sh` with `sk8s_step` / `sk8s_fail` used by `validate.sh`
- Improve contextual errors in backup CLI, SQL URI parsing, API docs generator, and repo helper
- Add Rust and shell smoke tests for representative error paths

## Test plan
- [x] `cargo test` for `error` and backup diagnostic tests
- [x] `scripts/dev-utils/test-error-diagnostics.sh`
- [ ] CI lint/format/test pass

Closes #901