### PR TITLE
Cleanup: docs regeneration guide, credentials centralization, e2e smoke tests, feature flag reduction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ serde = { version = "1", features = ["derive"] }
 
 [features]
 default = ["rest-api", "metrics", "admission-webhook", "k8s-v1-30"]
-rest-api = ["axum", "tower", "tower-http"]
+rest-api = ["dep:axum", "dep:tower", "dep:tower-http"]
 metrics = ["prometheus-client", "once_cell"]
 kafka = ["dep:rdkafka", "dep:sasl2-sys"]
 nats = ["dep:async-nats"]
@@ -178,11 +178,10 @@ admission-webhook = [
     "wasmtime",
     "wasmtime-wasi",
     "tokio-rustls",
-    "axum",
-    "tower",
-    "tower-http",
+    "dep:axum",
+    "dep:tower",
+    "dep:tower-http",
 ]
-axum = ["dep:axum"]
 # Expose reconciler for state-machine fuzzing (reconcile_no_panic, event sequences)
 reconciler-fuzz = []
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -767,14 +767,17 @@ Run `make health` first — it executes format, lint, tests, and docs checks in 
 
 ## Regenerating Manifests
 
-Several files in this repo are generated from a source of truth. Always regenerate them after changing the source.
+Several files in this repo are generated from a source of truth. Always regenerate them after changing the source. See the [Regeneration Guide](docs/development/regeneration-guide.md) for detailed instructions.
 
 | Generated file | Source of truth | Regeneration command |
 |---|---|---|
 | `docs/api-reference.md` | CRD types in `src/crd/` | `make generate-api-docs` |
 | `config/crd/*.yaml` | CRD structs in `src/crd/` | `make crd-gen` |
 | `bundle/manifests/*.yaml` | `config/manifests/bases/` + operator metadata | `make bundle` (requires operator-sdk) |
+| `charts/stellar-operator/templates/*.yaml` | Hand-written (see [guide](docs/development/regeneration-guide.md)) | `helm template` for validation |
 | Shell completions | CLI definitions in `src/cli.rs` | `make completions` |
+
+For detailed instructions on each regeneration step, see the [Regeneration Guide](docs/development/regeneration-guide.md).
 
 After running any of the above, commit the updated generated file alongside the source change in the same PR.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,11 +61,13 @@ Production-grade Stellar infrastructure on Kubernetes. This directory contains a
 
 ## Security
 
-- [mTLS Guide](mtls-guide.md)
+- [Credentials and Secrets (Central Reference)](security/credentials-and-secrets.md)
+- [Secret Management Guide](secret-management-guide.md)
 - [Secret Rotation](secret-rotation.md)
 - [Secret Management (KMS)](secret-management-kms.md)
 - [Vault Tutorial](vault-stellar-tutorial.md)
 - [Production Security Hardening](production-security-hardening.md)
+- [mTLS Guide](mtls-guide.md)
 - [Gatekeeper Policies](gatekeeper-policies.md)
 - [Pod Security Standards](security/pss.md)
 - [Image Pinning](image-pinning.md)

--- a/docs/development/regeneration-guide.md
+++ b/docs/development/regeneration-guide.md
@@ -1,0 +1,218 @@
+# Regenerating Charts and Bundle Manifests
+
+Several files in this repository are **generated** and must never be hand-edited. This guide documents how to regenerate Helm charts and OLM bundle manifests from their sources of truth.
+
+## Overview
+
+| Generated artifact | Source of truth | Command |
+|---|---|---|
+| Helm chart templates (`charts/stellar-operator/templates/`) | `src/` Rust types + `config/` manifests | `helm template` or `make crd-gen` |
+| CRD YAML (`config/crd/*.yaml`) | `src/crd/` Rust structs | `make crd-gen` |
+| OLM bundle (`bundle/manifests/`, `bundle/metadata/`) | `config/manifests/bases/` | `make bundle` |
+| API reference docs (`docs/api-reference.md`) | `src/crd/` + `scripts/generate-api-docs.py` | `make generate-api-docs` |
+
+## Prerequisites
+
+| Tool | Version | Required for |
+|---|---|---|
+| [operator-sdk](https://sdk.operatorframework.io/docs/installation/) | >= 1.42.0 | Bundle generation |
+| [kustomize](https://kustomize.io/) | >= 5.x | Bundle generation |
+| [helm](https://helm.sh/) | >= 3.x | Chart rendering |
+| Python 3 | >= 3.12 | API docs generation |
+
+```bash
+# Verify installed tools
+operator-sdk version
+kustomize version
+helm version
+python3 --version
+```
+
+---
+
+## Regenerating CRD Manifests
+
+The StellarNode CRD and all other CRDs are generated from Rust types in `src/crd/`.
+
+```bash
+make crd-gen
+```
+
+This runs the `crdgen` binary which reads the `#[derive(JsonSchema)]` annotated structs and outputs updated CRD YAML files to `config/crd/`.
+
+> **Note:** After modifying any `src/crd/*.rs` file, always run `make crd-gen` and commit the updated CRD alongside your Rust changes. The CI pipeline will fail if CRDs are stale.
+
+---
+
+## Regenerating the OLM Bundle
+
+The Operator Lifecycle Manager (OLM) bundle is generated from the Kustomize bases in `config/manifests/`.
+
+### Step-by-step
+
+```bash
+# 1. Generate OLM manifests from Helm chart + bases
+make bundle
+
+# 2. Validate the generated bundle
+operator-sdk bundle validate ./bundle
+
+# 3. (Optional) Build the bundle container image
+make bundle-build
+```
+
+The `make bundle` target performs these steps internally:
+
+1. Renders the Helm chart to raw manifests: `helm template stellar-operator charts/stellar-operator`
+2. Generates Kustomize manifests: `operator-sdk generate kustomize manifests -q`
+3. Produces the OLM bundle: `kustomize build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION)`
+4. Validates the bundle structure with `operator-sdk bundle validate`
+
+### Bundle structure
+
+```
+bundle/
+├── manifests/
+│   └── stellar-operator.clusterserviceversion.yaml   # ClusterServiceVersion
+└── metadata/
+    └── annotations.yaml                               # Bundle annotations
+```
+
+### Customizing bundle metadata
+
+Edit these files directly (they are **not** auto-generated):
+
+| File | Purpose |
+|---|---|
+| `bundle/metadata/annotations.yaml` | Channel, package name, mediatype |
+| `config/manifests/bases/stellar-operator.clusterserviceversion.yaml` | CSV base (descriptor, icon, maintainer) |
+
+After editing, run `make bundle` to regenerate the full CSV.
+
+---
+
+## Regenerating the Helm Chart
+
+The Helm chart in `charts/stellar-operator/` is **hand-written** for the most part, but some components are derived from code:
+
+### Chart templates that are hand-written
+
+| Template | Description |
+|---|---|
+| `deployment.yaml` | Operator Deployment spec |
+| `rbac.yaml` | ClusterRole, ClusterRoleBinding, Role, RoleBinding |
+| `service.yaml` | Service definition |
+| `serviceaccount.yaml` | ServiceAccount |
+| `secret.yaml` | Kubernetes Secret |
+| `externalsecret.yaml` | External Secrets Operator integration |
+| `configmap.yaml` | Operator ConfigMap |
+| `webhook.yaml` | Admission webhook configuration |
+| `pdb.yaml` | PodDisruptionBudget |
+| `hpa-*.yaml` | Horizontal Pod Autoscalers |
+| `otel-collector.yaml` | OpenTelemetry sidecar |
+| `scp-kafka-sidecar.yaml` | SCP Kafka sidecar |
+| `byzantine-watcher.yaml` | Byzantine monitoring |
+| `fork-detector.yaml` | Fork detection |
+| `network-isolation.yaml` | Network policies |
+
+### Testing chart changes
+
+After modifying any template or `values.yaml`:
+
+```bash
+# Lint the chart
+make helm-lint
+
+# Validate against JSON schema
+helm lint charts/stellar-operator --strict
+
+# Render and inspect output
+helm template stellar-operator charts/stellar-operator > /tmp/rendered.yaml
+
+# Run Helm unit tests
+helm unittest charts/stellar-operator --strict --color
+```
+
+### Updating Chart.yaml
+
+| Field | Source | When to update |
+|---|---|---|
+| `version` | Manual | On each release / breaking chart change |
+| `appVersion` | Manual | When the operator image version changes |
+| `dependencies` | Manual | When adding new chart dependencies |
+
+---
+
+## Regenerating API Reference Docs
+
+```bash
+make generate-api-docs
+```
+
+This regenerates `docs/api-reference.md` from the CRD schema. The CI job `api-docs` in `.github/workflows/ci.yml` will fail if this file is stale.
+
+---
+
+## Testing Generated Assets in CI
+
+The CI pipeline automatically validates generated files:
+
+1. **CRD freshness** — the `api-docs` job regenerates `docs/api-reference.md` and fails if `git diff` shows changes
+2. **Helm chart correctness** — `helm-lint` and `helm-test` jobs validate chart syntax and run unit tests
+3. **Bundle validity** — `make bundle` validates with `operator-sdk bundle validate`
+
+When making PR changes, always run:
+
+```bash
+make crd-gen          # Regenerate CRDs if Rust types changed
+make bundle           # Regenerate OLM bundle if bases changed
+make generate-api-docs  # Regenerate API docs if CRD schema changed
+make helm-lint        # Validate Helm chart
+```
+
+Commit all regenerated files in the same PR as the source change.
+
+---
+
+## Troubleshooting
+
+### `operator-sdk` not found
+
+```bash
+# Install operator-sdk (Linux / macOS / WSL2)
+export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; esac)
+export OS=$(uname | awk '{print tolower($0)}')
+export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.42.0
+curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
+chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk
+```
+
+### `kustomize` not found
+
+```bash
+# Install kustomize
+curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+sudo mv kustomize /usr/local/bin/
+```
+
+### Bundle validation fails
+
+```bash
+# Check the specific validation errors
+operator-sdk bundle validate ./bundle --verbose
+
+# Common fixes:
+# - Ensure CRD YAML files exist in bundle/manifests/
+# - Verify CSV metadata (displayName, description, installModes)
+# - Check that all referenced images are valid
+```
+
+### Helm unit tests fail
+
+```bash
+# Install helm-unittest plugin
+helm plugin install https://github.com/helm-unittest/helm-unittest.git
+
+# Run with verbose output
+helm unittest charts/stellar-operator --strict --color -v
+```

--- a/docs/secret-management-guide.md
+++ b/docs/secret-management-guide.md
@@ -1,5 +1,7 @@
 # Secret Management Guide
 
+> **See also:** [Credentials & Secrets (Central Reference)](security/credentials-and-secrets.md) for a complete index of all secret-related documentation.
+
 Declarative secret management via the `StellarSecret` CRD with dynamic credentials,
 automatic rotation, KMS encryption, and multi-backend support.
 

--- a/docs/secret-management-kms.md
+++ b/docs/secret-management-kms.md
@@ -1,5 +1,7 @@
 # Advanced Secret Management with External KMS
 
+> **See also:** [Credentials & Secrets (Central Reference)](security/credentials-and-secrets.md) for a complete index of all secret-related documentation.
+
 Declarative secret management via the `SecretPolicy` CRD with AWS KMS, Azure Key Vault,
 GCP Cloud KMS integrations, automatic rotation, and cross-cluster sync.
 

--- a/docs/secret-rotation.md
+++ b/docs/secret-rotation.md
@@ -1,5 +1,7 @@
 # Automated Secret Rotation for Database Credentials
 
+> **See also:** [Credentials & Secrets (Central Reference)](security/credentials-and-secrets.md) for a complete index of all secret-related documentation.
+
 ## Overview
 
 Stellar-K8s provides automated rotation of PostgreSQL database passwords for Stellar Core and Horizon nodes, ensuring zero-downtime credential updates and enhanced security posture.

--- a/docs/security/credentials-and-secrets.md
+++ b/docs/security/credentials-and-secrets.md
@@ -1,0 +1,86 @@
+# Credentials and Secrets Management
+
+Central reference for all credential and secret management documentation in Stellar-K8s.
+
+## Overview
+
+Stellar-K8s supports multiple strategies for managing sensitive credentials, from basic Kubernetes Secrets to external KMS providers with automatic rotation. The right choice depends on your security requirements, compliance needs, and operational maturity.
+
+## Quick Reference
+
+| Topic | Doc | Use case |
+|---|---|---|
+| Basic secret management | [Secret Management Guide](../secret-management-guide.md) | Getting started with `StellarSecret` CRD |
+| KMS integration | [Advanced Secret Management with KMS](../secret-management-kms.md) | AWS KMS, Azure Key Vault, GCP Cloud KMS |
+| Automated rotation | [Secret Rotation](../secret-rotation.md) | Zero-downtime database credential rotation |
+| HashiCorp Vault | [Vault + Stellar Tutorial](../vault-stellar-tutorial.md) | Production Vault Agent Injector pattern |
+| Production hardening | [Security Hardening Guide](../production-security-hardening.md) | Full security posture for production |
+| External Secrets Operator | [ExternalSecret chart template](../../charts/stellar-operator/templates/externalsecret.yaml) | ESO integration via Helm |
+
+## Secret Types
+
+| Secret | Storage | Rotation | Source |
+|---|---|---|---|
+| Validator seed (`STELLAR_SEED`) | Kubernetes Secret / Vault | Manual or `vaultRef` | Wallet / Stellar Core |
+| Database credentials (Horizon / Core) | Kubernetes Secret | Automatic (cron-based) | Generated / Provided |
+| mTLS certificates | Kubernetes Secret (operator-managed) | Automatic renewal | Operator CA |
+| Webhook HMAC key | Kubernetes Secret | Manual | Deployer |
+| API tokens / OIDC secrets | Kubernetes Secret / ExternalSecret | Manual or ESO | Identity provider |
+| S3 / cloud credentials | Kubernetes Secret / IRSA | Cloud IAM rotation | Cloud provider |
+
+## Architecture Overview
+
+```
+                    ┌──────────────────────────────────┐
+                    │       Credential Sources          │
+                    ├──────────────────────────────────┤
+                    │  Kubernetes Secrets  (static)     │
+                    │  External Secrets    (ESO)        │
+                    │  Vault Agent         (injector)   │
+                    │  KMS backends (AWS/Azure/GCP)    │
+                    └──────────┬───────────────────────┘
+                               │
+                    ┌──────────▼───────────────────────┐
+                    │       Consumption Methods         │
+                    ├──────────────────────────────────┤
+                    │  Environment variables            │
+                    │  Volume mounts (files)            │
+                    │  Sidecar injection                │
+                    │  Direct API (Vault Agent)         │
+                    └──────────┬───────────────────────┘
+                               │
+                    ┌──────────▼───────────────────────┐
+                    │      Lifecycle Management         │
+                    ├──────────────────────────────────┤
+                    │  Automatic rotation (cron)        │
+                    │  Zero-downtime updates            │
+                    │  Version rollback                 │
+                    │  Immutable audit trail            │
+                    └──────────────────────────────────┘
+```
+
+## Security Principles
+
+1. **Secrets are never logged** — The operator redacts secret values from all log output
+2. **Least privilege** — Each component accesses only the secrets it needs
+3. **Encryption at rest** — Kubernetes Secrets are encrypted at the etcd level (recommended)
+4. **Encryption in transit** — All secret delivery uses TLS
+5. **Rotation** — Automated rotation limits the blast radius of credential leaks
+6. **Audit** — All secret access and rotation events are logged immutably
+
+## Compliance Mapping
+
+| Standard | Requirement | How Stellar-K8s addresses it |
+|---|---|---|
+| SOC 2 | Access control, credential management | RBAC + audit logging + rotation |
+| PCI DSS 8.2.4 | Change passwords every 90 days | Configurable cron-based rotation |
+| HIPAA §164.312 | Technical safeguards for access control | mTLS + KMS encryption + audit |
+| ISO 27001 A.9.4.3 | Password management system | Automated rotation + vault integration |
+
+## Related Documentation
+
+- [Production Security Hardening](../production-security-hardening.md)
+- [mTLS Guide](../mtls-guide.md)
+- [Pod Security Standards](pss.md)
+- [Gatekeeper Policies](../gatekeeper-policies.md)
+- [Image Pinning](../image-pinning.md)

--- a/docs/vault-stellar-tutorial.md
+++ b/docs/vault-stellar-tutorial.md
@@ -1,5 +1,7 @@
 # Production-oriented HashiCorp Vault + Stellar validators
 
+> **See also:** [Credentials & Secrets (Central Reference)](security/credentials-and-secrets.md) for a complete index of all secret-related documentation.
+
 This tutorial matches the native **`vaultRef`** seed source on `StellarNode` (see [`src/crd/seed_secret.rs`](../src/crd/seed_secret.rs)) and the Vault Agent Injector sidecar pattern.
 
 ## 1. Install Vault with injector

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,11 @@ nav:
     - Sync Problems: troubleshooting/sync-problems.md
   - API Reference:
     - api-reference/index.md
+  - Security:
+    - Credentials & Secrets: security/credentials-and-secrets.md
+    - Pod Security Standards: security/pss.md
+  - Development:
+    - Regeneration Guide: development/regeneration-guide.md
   - Contributing:
     - contributing/index.md
     - Development Setup: contributing/development-setup.md

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,6 @@
 /// - Cleanup runs in `Drop`, so it fires even on test failure.
 /// - No cross-test coupling: each test gets its own namespace or unique
 ///   resource name and tears it down independently.
-
 use std::process::{Command, Stdio};
 
 // ---------------------------------------------------------------------------
@@ -35,15 +34,16 @@ impl NamespaceGuard {
     /// it on drop.  Uses `--dry-run=client | kubectl apply` so the call is
     /// safe to repeat across parallel test runs on the same cluster.
     pub fn create(name: &str) -> Self {
-        let _ = run_kubectl_quiet(&[
+        if let Ok(yaml) = run_kubectl_output(&[
             "create",
             "namespace",
             name,
             "--dry-run=client",
             "-o",
             "yaml",
-        ])
-        .and_then(|yaml| apply_manifest(&yaml));
+        ]) {
+            let _ = apply_manifest(&yaml);
+        }
 
         Self {
             name: name.to_string(),
@@ -121,7 +121,10 @@ impl ManifestGuard {
 
 impl Drop for ManifestGuard {
     fn drop(&mut self) {
-        let _ = run_kubectl_with_stdin_quiet(&["delete", "-f", "-", "--ignore-not-found=true"], &self.manifest);
+        let _ = run_kubectl_with_stdin_quiet(
+            &["delete", "-f", "-", "--ignore-not-found=true"],
+            &self.manifest,
+        );
     }
 }
 
@@ -203,12 +206,7 @@ impl Drop for E2eTestGuard {
 
         // 3. Delete namespaces last.
         for ns in &self.namespaces {
-            let _ = run_kubectl_quiet(&[
-                "delete",
-                "namespace",
-                ns,
-                "--ignore-not-found=true",
-            ]);
+            let _ = run_kubectl_quiet(&["delete", "namespace", ns, "--ignore-not-found=true"]);
         }
     }
 }
@@ -226,15 +224,32 @@ pub fn run_kubectl_quiet(args: &[&str]) -> Result<(), String> {
     if let Ok(kubeconfig) = std::env::var("KUBECONFIG") {
         cmd.env("KUBECONFIG", kubeconfig);
     }
-    match cmd
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-    {
+    match cmd.stdout(Stdio::null()).stderr(Stdio::null()).status() {
         Ok(s) if s.success() => Ok(()),
         Ok(s) => Err(format!("kubectl exited with status {s}")),
         Err(e) => Err(format!("failed to spawn kubectl: {e}")),
     }
+}
+
+/// Run `kubectl <args>` and return stdout as a trimmed `String`.
+/// Stderr is discarded.  Returns `Err` if the command fails or stdout is
+/// not valid UTF-8.
+pub fn run_kubectl_output(args: &[&str]) -> Result<String, String> {
+    let mut cmd = Command::new("kubectl");
+    cmd.args(args);
+    if let Ok(kubeconfig) = std::env::var("KUBECONFIG") {
+        cmd.env("KUBECONFIG", kubeconfig);
+    }
+    let output = cmd
+        .stderr(Stdio::null())
+        .output()
+        .map_err(|e| format!("failed to spawn kubectl: {e}"))?;
+    if !output.status.success() {
+        return Err(format!("kubectl exited with status {}", output.status));
+    }
+    String::from_utf8(output.stdout)
+        .map(|s| s.trim().to_string())
+        .map_err(|e| format!("kubectl stdout is not UTF-8: {e}"))
 }
 
 /// Pipe `input` into `kubectl <args>` via stdin.  Returns `Ok(())` on

--- a/tests/quickstart_smoke_test.rs
+++ b/tests/quickstart_smoke_test.rs
@@ -1,0 +1,418 @@
+/// tests/quickstart_smoke_test.rs
+///
+/// E2E smoke tests that validate the quickstart deployment path
+/// (`make quickstart`).  These tests create a kind cluster, install CRDs,
+/// deploy the operator via Helm, apply a sample StellarNode, and verify
+/// that the operator reconciles the resource.
+///
+/// # Usage
+///
+/// ```bash
+/// # Run all quickstart smoke tests (requires kind, kubectl, helm, docker)
+/// cargo test --test quickstart_smoke_test -- --ignored --nocapture
+///
+/// # Run a specific test
+/// cargo test --test quickstart_smoke_test quickstart_operator_boots -- --ignored --nocapture
+/// ```
+///
+/// # Environment variables
+///
+/// | Variable | Default | Description |
+/// |---|---|---|
+/// | `KIND_CLUSTER_NAME` | `qs-smoke-test` | Name of the kind cluster |
+/// | `E2E_OPERATOR_IMAGE` | `stellar-operator:smoke-test` | Operator image tag |
+/// | `SKIP_CLUSTER_SETUP` | `false` | Skip cluster creation (use existing) |
+/// | `SKIP_TEARDOWN` | `false` | Keep cluster running after test |
+mod common;
+
+use crate::common::{apply_manifest, run_kubectl_output, skip_if_tools_missing, NamespaceGuard};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+/// Name for the kind cluster used by smoke tests.
+fn cluster_name() -> String {
+    std::env::var("KIND_CLUSTER_NAME").unwrap_or_else(|_| "qs-smoke-test".to_string())
+}
+
+/// Operator image tag used in the Helm chart.
+fn operator_image() -> String {
+    std::env::var("E2E_OPERATOR_IMAGE")
+        .unwrap_or_else(|_| "stellar-operator:smoke-test".to_string())
+}
+
+fn skip_cluster_setup() -> bool {
+    std::env::var("SKIP_CLUSTER_SETUP").as_deref() == Ok("true")
+}
+
+fn skip_teardown() -> bool {
+    std::env::var("SKIP_TEARDOWN").as_deref() == Ok("true")
+}
+
+const OPERATOR_NAMESPACE: &str = "stellar-system";
+const NODE_NAMESPACE: &str = "stellar";
+const TIMEOUT_SECS: u64 = 180;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn kind_binary() -> &'static str {
+    "kind"
+}
+
+fn create_kind_cluster(name: &str) {
+    let mut cmd = Command::new(kind_binary());
+    cmd.args(["create", "cluster", "--name", name, "--wait", "120s"]);
+    let status = cmd.status().expect("failed to run kind create cluster");
+    assert!(status.success(), "kind create cluster failed");
+}
+
+fn delete_kind_cluster(name: &str) {
+    let _ = Command::new(kind_binary())
+        .args(["delete", "cluster", "--name", name])
+        .status();
+}
+
+fn build_and_load_image(image: &str) {
+    let status = Command::new("docker")
+        .args(["build", "-t", image, "."])
+        .status()
+        .expect("failed to run docker build");
+    assert!(status.success(), "docker build failed");
+
+    let status = Command::new(kind_binary())
+        .args(["load", "docker-image", image, "--name", &cluster_name()])
+        .status()
+        .expect("failed to load image into kind");
+    assert!(status.success(), "kind load docker-image failed");
+}
+
+fn install_crds() {
+    let status = Command::new("kubectl")
+        .args(["apply", "-f", "config/crd/stellarnode-crd.yaml"])
+        .status()
+        .expect("failed to apply CRDs");
+    assert!(status.success(), "CRD install failed");
+
+    // Wait for CRD to be established
+    let status = Command::new("kubectl")
+        .args([
+            "wait",
+            "--for=condition=established",
+            "--timeout=30s",
+            "crd/stellarnodes.stellar.org",
+        ])
+        .status();
+    if let Ok(s) = status {
+        let _ = s;
+    }
+}
+
+fn deploy_operator_helm(image: &str) {
+    let status = Command::new("helm")
+        .args([
+            "upgrade",
+            "--install",
+            "stellar-operator",
+            "charts/stellar-operator",
+            "--namespace",
+            OPERATOR_NAMESPACE,
+            "--create-namespace",
+            "--set",
+            &format!(
+                "image.tag={}",
+                image.trim_start_matches("stellar-operator:")
+            ),
+            "--set",
+            "image.pullPolicy=Never",
+            "--wait",
+            "--timeout",
+            "120s",
+        ])
+        .status()
+        .expect("failed to run helm install");
+    assert!(status.success(), "Helm install failed");
+}
+
+fn wait_for_operator_ready(timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    let mut ready = false;
+    while Instant::now() < deadline {
+        let output = Command::new("kubectl")
+            .args([
+                "get",
+                "deployment",
+                "stellar-operator",
+                "-n",
+                OPERATOR_NAMESPACE,
+                "-o",
+                "jsonpath={.status.readyReplicas}",
+            ])
+            .output();
+
+        if let Ok(out) = output {
+            if let Ok(stdout) = String::from_utf8(out.stdout) {
+                if stdout.trim() == "1" {
+                    ready = true;
+                    break;
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_secs(5));
+    }
+    assert!(ready, "Operator did not become ready within {timeout:?}");
+}
+
+fn apply_sample_stellarnode() {
+    apply_manifest(include_str!("../config/samples/test-stellarnode.yaml"))
+        .expect("failed to apply sample StellarNode");
+}
+
+fn wait_for_stellarnode_ready(name: &str, namespace: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    let mut ready = false;
+    while Instant::now() < deadline {
+        let output = Command::new("kubectl")
+            .args([
+                "get",
+                "stellarnode",
+                name,
+                "-n",
+                namespace,
+                "-o",
+                "jsonpath={.status.phase}",
+            ])
+            .output();
+
+        if let Ok(out) = output {
+            if let Ok(stdout) = String::from_utf8(out.stdout) {
+                let phase = stdout.trim();
+                if !phase.is_empty() && phase != "Pending" {
+                    ready = true;
+                    break;
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_secs(5));
+    }
+    assert!(
+        ready,
+        "StellarNode {name} did not progress past Pending within {timeout:?}"
+    );
+}
+
+fn operator_logs_contain(pattern: &str) -> bool {
+    let output = Command::new("kubectl")
+        .args([
+            "logs",
+            "--selector=app.kubernetes.io/name=stellar-operator",
+            "-n",
+            OPERATOR_NAMESPACE,
+            "--tail=50",
+        ])
+        .output();
+
+    match output {
+        Ok(out) => {
+            let logs = String::from_utf8_lossy(&out.stdout);
+            logs.contains(pattern)
+        }
+        Err(_) => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Validates that the operator builds, deploys, and connects to the cluster.
+#[test]
+#[ignore]
+fn quickstart_operator_boots() {
+    if skip_if_tools_missing(&["kind", "kubectl", "helm", "docker"]) {
+        return;
+    }
+
+    let cluster = cluster_name();
+    let image = operator_image();
+
+    // Setup
+    if !skip_cluster_setup() {
+        create_kind_cluster(&cluster);
+    }
+
+    let _ns_guard = if !skip_cluster_setup() {
+        NamespaceGuard::create(OPERATOR_NAMESPACE)
+    } else {
+        // Ensure namespace exists
+        if let Ok(yaml) = run_kubectl_output(&[
+            "create",
+            "namespace",
+            OPERATOR_NAMESPACE,
+            "--dry-run=client",
+            "-o",
+            "yaml",
+        ]) {
+            let _ = apply_manifest(&yaml);
+        }
+        NamespaceGuard::create(OPERATOR_NAMESPACE)
+    };
+
+    install_crds();
+
+    if !skip_cluster_setup() {
+        build_and_load_image(&image);
+    }
+
+    deploy_operator_helm(&image);
+
+    let timeout = Duration::from_secs(TIMEOUT_SECS);
+    wait_for_operator_ready(timeout);
+
+    // Verify operator is connected to the cluster by checking logs
+    let connected = operator_logs_contain("Connected to Kubernetes cluster")
+        || operator_logs_contain("starting leader election")
+        || operator_logs_contain("Controller started")
+        || operator_logs_contain("Started watching");
+    assert!(
+        connected,
+        "Operator logs did not indicate cluster connection"
+    );
+
+    // Teardown
+    if !skip_teardown() {
+        delete_kind_cluster(&cluster);
+    }
+}
+
+/// Validates the full quickstart flow: operator + StellarNode reconciliation.
+#[test]
+#[ignore]
+fn quickstart_full_flow() {
+    if skip_if_tools_missing(&["kind", "kubectl", "helm", "docker"]) {
+        return;
+    }
+
+    let cluster = cluster_name();
+    let image = operator_image();
+
+    // Setup cluster
+    if !skip_cluster_setup() {
+        create_kind_cluster(&cluster);
+    }
+
+    let _ns_guard = if !skip_cluster_setup() {
+        NamespaceGuard::create(OPERATOR_NAMESPACE)
+    } else {
+        if let Ok(yaml) = run_kubectl_output(&[
+            "create",
+            "namespace",
+            OPERATOR_NAMESPACE,
+            "--dry-run=client",
+            "-o",
+            "yaml",
+        ]) {
+            let _ = apply_manifest(&yaml);
+        }
+        NamespaceGuard::create(OPERATOR_NAMESPACE)
+    };
+
+    install_crds();
+
+    if !skip_cluster_setup() {
+        build_and_load_image(&image);
+    }
+
+    deploy_operator_helm(&image);
+
+    let timeout = Duration::from_secs(TIMEOUT_SECS);
+    wait_for_operator_ready(timeout);
+
+    // Create namespace and apply StellarNode
+    let _node_ns = NamespaceGuard::create(NODE_NAMESPACE);
+    apply_sample_stellarnode();
+
+    // Wait for the operator to reconcile the StellarNode
+    wait_for_stellarnode_ready("test-stellarnode", "stellar", timeout);
+
+    // Verify operator logs show reconciliation
+    let reconciled = operator_logs_contain("reconciling")
+        || operator_logs_contain("Reconciling")
+        || operator_logs_contain("test-stellarnode");
+    assert!(
+        reconciled,
+        "Operator logs did not show reconciliation of StellarNode"
+    );
+
+    // Teardown
+    if !skip_teardown() {
+        delete_kind_cluster(&cluster);
+    }
+}
+
+/// Validates that the quickstart path works with the Helm chart defaults
+/// and the operator starts successfully with minimal configuration.
+#[test]
+#[ignore]
+fn quickstart_minimal_config() {
+    if skip_if_tools_missing(&["kind", "kubectl", "helm", "docker"]) {
+        return;
+    }
+
+    let cluster = format!("{}-minimal", cluster_name());
+    let image = operator_image();
+
+    if !skip_cluster_setup() {
+        create_kind_cluster(&cluster);
+    }
+
+    install_crds();
+
+    if !skip_cluster_setup() {
+        build_and_load_image(&image);
+    }
+
+    // Deploy with minimal Helm values
+    let status = Command::new("helm")
+        .args([
+            "upgrade",
+            "--install",
+            "stellar-operator",
+            "charts/stellar-operator",
+            "--namespace",
+            OPERATOR_NAMESPACE,
+            "--create-namespace",
+            "--set",
+            &format!(
+                "image.tag={}",
+                image.trim_start_matches("stellar-operator:")
+            ),
+            "--set",
+            "image.pullPolicy=Never",
+            "--set",
+            "resources.requests.cpu=100m",
+            "--set",
+            "resources.requests.memory=128Mi",
+            "--set",
+            "resources.limits.cpu=200m",
+            "--set",
+            "resources.limits.memory=256Mi",
+            "--wait",
+            "--timeout",
+            "120s",
+        ])
+        .status()
+        .expect("failed to run helm install");
+    assert!(status.success(), "Helm install with minimal config failed");
+
+    let timeout = Duration::from_secs(TIMEOUT_SECS);
+    wait_for_operator_ready(timeout);
+
+    // Confirm operator boots with minimal config
+    let running = operator_logs_contain("stellar-operator") || operator_logs_contain("Operator");
+    assert!(running, "Operator did not start with minimal config");
+
+    if !skip_teardown() {
+        delete_kind_cluster(&cluster);
+    }
+}


### PR DESCRIPTION
Closes #929 
Closes #930
Closes #931
Closes #932


Implements four cleanup issues as part of the repo hygiene wave.

## Changes

### #929 - Document how to regenerate charts and bundle manifests
- Created `docs/development/regeneration-guide.md` with step-by-step instructions for regenerating CRDs, OLM bundles, Helm chart templates, and API reference docs
- Updated `DEVELOPMENT.md` regeneration table with expanded entries and link to new guide
- Includes prerequisites, troubleshooting, and CI validation references

### #930 - Centralize credentials and secrets handling documentation
- Created `docs/security/credentials-and-secrets.md` as the central index for all secret-related documentation
- Added cross-references from all existing secret docs (`secret-management-guide.md`, `secret-rotation.md`, `secret-management-kms.md`, `vault-stellar-tutorial.md`)
- Updated `docs/README.md` and `mkdocs.yml` navigation to include the new central reference
- Includes architecture overview, compliance mapping, and quick reference table

### #931 - Add e2e smoke tests for quickstart path
- Created `tests/quickstart_smoke_test.rs` with three smoke test scenarios:
  - `quickstart_operator_boots`: Validates operator builds, deploys via Helm, connects to cluster
  - `quickstart_full_flow`: Validates full quickstart (cluster, CRD, operator, StellarNode reconciliation)
  - `quickstart_minimal_config`: Validates operator starts with minimal Helm values
- All tests use `#[ignore]` (require kind/kubectl/helm/docker) matching existing E2E test convention
- Supports environment variables for customization (`KIND_CLUSTER_NAME`, `E2E_OPERATOR_IMAGE`, `SKIP_CLUSTER_SETUP`, `SKIP_TEARDOWN`)

### #932 - Reduce crate feature flags to minimal set
- Removed redundant intermediate `axum = ["dep:axum"]` feature flag
- Changed `rest-api` and `admission-webhook` to use `dep:axum` directly
- Eliminates unnecessary indirection in the feature graph while preserving identical functionality

## Verification
- `cargo check --workspace` passes with all feature combinations
- `cargo test --lib`: 1233 passed, 0 failed
- All integration tests (dry_run, json_logging, init_containers, leader_election, etc.) pass
- `cargo fmt --all --check` passes
