### PR TITLE
[1003] Consolidate duplicate shell helper logic across batch scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 	benchmark-webhook-compare benchmark-webhook-save benchmark-all \
 	compose-up compose-dev compose-down compose-logs \
 	bundle bundle-build \
-	quickstart validate preflight test-preflight all \
+	quickstart validate preflight test-preflight test-shell all \
 	clean
 
 # Default target
@@ -164,6 +164,11 @@ test-preflight: ## Run bats unit tests for scripts/preflight.sh
 	@echo "→ Running preflight bats tests..."
 	@command -v bats >/dev/null 2>&1 || (echo "✗ bats not installed. See https://github.com/bats-core/bats-core" && exit 1)
 	@bats scripts/tests/preflight.bats
+
+test-shell: ## Run bats unit tests for shared shell helpers
+	@echo "→ Running shell helper bats tests..."
+	@command -v bats >/dev/null 2>&1 || (echo "✗ bats not installed. See https://github.com/bats-core/bats-core" && exit 1)
+	@bats scripts/tests/common.bats
 
 completions: ## Generate shell completion scripts
 	@echo "→ Generating shell completions..."

--- a/scripts/archive/README.md
+++ b/scripts/archive/README.md
@@ -4,6 +4,19 @@ This directory holds historical and one-off scripts that were used during initia
 repository setup and issue management. They are **not** part of the normal development
 or operational workflow.
 
+## Shared helpers
+
+Batch scripts source shared logic from:
+
+- `scripts/lib/common.sh` — repository resolution, dry-run handling, and `create_issue` retry logic
+- `scripts/lib/batch.sh` — standard `--help` output, issue-count validation, and the `create_issue_with_retry` alias
+
+All archived scripts use:
+
+```bash
+source "$(dirname "$0")/../lib/batch.sh"
+```
+
 ## Contents
 
 - `create_batch_*.sh` — GitHub issue creation scripts used to seed the issue tracker

--- a/scripts/archive/create_batch_10_issues.sh
+++ b/scripts/archive/create_batch_10_issues.sh
@@ -1,51 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Wave (Batch 10, 8 x 200 pts + 2 x 150 pts).
-
-Prerequisites:
-  - gh CLI installed and authenticated (gh auth login)
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-  MAX_RETRIES         Number of retry attempts on API failure (default: 10)
-  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Wave (Batch 10, 8 x 200 pts + 2 x 150 pts)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=10
-ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 10 (8 x 200 pts, 2 x 150 pts) issues with auto-retry..."
+echo "Creating Batch 10 (8 x 200 pts, 2 x 150 pts) issues with auto-retry.."
 
 # Alias kept for readability; delegates to the shared helper.
-create_issue_with_retry() { create_issue "$1" "$2" "$3"; }
 
 # ─── ISSUE 1 (200 pts) ────────────────────────────────────────────────────────
 create_issue_with_retry \

--- a/scripts/archive/create_batch_11_issues.sh
+++ b/scripts/archive/create_batch_11_issues.sh
@@ -1,51 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Wave (Batch 11, 5 x 150 pts).
-
-Prerequisites:
-  - gh CLI installed and authenticated (gh auth login)
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-  MAX_RETRIES         Number of retry attempts on API failure (default: 10)
-  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Wave (Batch 11, 5 x 150 pts)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=5
-ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 11 (5 x 150 pts) issues with auto-retry..."
+echo "Creating Batch 11 (5 x 150 pts) issues with auto-retry.."
 
 # Alias kept for readability; delegates to the shared helper.
-create_issue_with_retry() { create_issue "$1" "$2" "$3"; }
 
 # ─── ISSUE 1 (150 pts) ────────────────────────────────────────────────────────
 create_issue_with_retry \

--- a/scripts/archive/create_batch_12_issues.sh
+++ b/scripts/archive/create_batch_12_issues.sh
@@ -1,51 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Wave (Batch 12, 15 x 200 pts).
-
-Prerequisites:
-  - gh CLI installed and authenticated (gh auth login)
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-  MAX_RETRIES         Number of retry attempts on API failure (default: 10)
-  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Wave (Batch 12, 15 x 200 pts)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=15
-ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 12 (15 x 200 pts) issues with auto-retry..."
+echo "Creating Batch 12 (15 x 200 pts) issues with auto-retry.."
 
 # Alias kept for readability; delegates to the shared helper.
-create_issue_with_retry() { create_issue "$1" "$2" "$3"; }
 
 # ─── ISSUE 1 (200 pts) ────────────────────────────────────────────────────────
 create_issue_with_retry \

--- a/scripts/archive/create_batch_13_issues.sh
+++ b/scripts/archive/create_batch_13_issues.sh
@@ -1,51 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Wave (Batch 13, 10 x 200 pts - 10k Milestone).
-
-Prerequisites:
-  - gh CLI installed and authenticated (gh auth login)
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-  MAX_RETRIES         Number of retry attempts on API failure (default: 10)
-  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Wave (Batch 13, 10 x 200 pts - 10k Milestone)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=10
-ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 13 (10 x 200 pts) - The 10k Milestone Batch..."
+echo "Creating Batch 13 (10 x 200 pts) - The 10k Milestone Batch.."
 
 # Alias kept for readability; delegates to the shared helper.
-create_issue_with_retry() { create_issue "$1" "$2" "$3"; }
 
 # ─── ISSUE 1 (200 pts) ────────────────────────────────────────────────────────
 create_issue_with_retry \

--- a/scripts/archive/create_batch_14_issues.sh
+++ b/scripts/archive/create_batch_14_issues.sh
@@ -1,51 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Wave (Batch 14, 5 x 150 pts).
-
-Prerequisites:
-  - gh CLI installed and authenticated (gh auth login)
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-  MAX_RETRIES         Number of retry attempts on API failure (default: 10)
-  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Wave (Batch 14, 5 x 150 pts)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=5
-ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 14 (5 x 150 pts) issues with auto-retry..."
+echo "Creating Batch 14 (5 x 150 pts) issues with auto-retry.."
 
 # Alias kept for readability; delegates to the shared helper.
-create_issue_with_retry() { create_issue "$1" "$2" "$3"; }
 
 # ─── ISSUE 1 (150 pts) ────────────────────────────────────────────────────────
 create_issue_with_retry \

--- a/scripts/archive/create_batch_15_issues.sh
+++ b/scripts/archive/create_batch_15_issues.sh
@@ -1,51 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Wave (Batch 15, 10 x 200 pts).
-
-Prerequisites:
-  - gh CLI installed and authenticated (gh auth login)
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-  MAX_RETRIES         Number of retry attempts on API failure (default: 10)
-  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Wave (Batch 15, 10 x 200 pts)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=10
-ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 15 (10 x 200 pts) issues with auto-retry..."
+echo "Creating Batch 15 (10 x 200 pts) issues with auto-retry.."
 
 # Alias kept for readability; delegates to the shared helper.
-create_issue_with_retry() { create_issue "$1" "$2" "$3"; }
 
 # ─── ISSUE 1 (200 pts) ────────────────────────────────────────────────────────
 create_issue_with_retry \

--- a/scripts/archive/create_batch_16_issues.sh
+++ b/scripts/archive/create_batch_16_issues.sh
@@ -1,51 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Wave (Batch 16, 20 x 200 pts).
-
-Prerequisites:
-  - gh CLI installed and authenticated (gh auth login)
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-  MAX_RETRIES         Number of retry attempts on API failure (default: 10)
-  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Wave (Batch 16, 20 x 200 pts)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=20
-ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 16 (20 x 200 pts) issues with auto-retry..."
+echo "Creating Batch 16 (20 x 200 pts) issues with auto-retry.."
 
 # Alias kept for readability; delegates to the shared helper.
-create_issue_with_retry() { create_issue "$1" "$2" "$3"; }
 
 # ─── 1 ────────────────────────────────────────────────────────────────────────
 create_issue_with_retry \

--- a/scripts/archive/create_batch_17_issues.sh
+++ b/scripts/archive/create_batch_17_issues.sh
@@ -1,51 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Wave (Batch 17, 30 x 200 pts).
-
-Prerequisites:
-  - gh CLI installed and authenticated (gh auth login)
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-  MAX_RETRIES         Number of retry attempts on API failure (default: 10)
-  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Wave (Batch 17, 30 x 200 pts)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=30
-ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 17 (30 x 200 pts) issues with auto-retry..."
+echo "Creating Batch 17 (30 x 200 pts) issues with auto-retry.."
 
 # Alias kept for readability; delegates to the shared helper.
-create_issue_with_retry() { create_issue "$1" "$2" "$3"; }
 
 # ─── 1 ────────────────────────────────────────────────────────────────────────
 create_issue_with_retry "Add Shell Completion for stellar-operator CLI" "stellar-wave,enhancement,dx" "### 🔴 Difficulty: High (200 Points)

--- a/scripts/archive/create_batch_18_issues.sh
+++ b/scripts/archive/create_batch_18_issues.sh
@@ -1,51 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Wave (Batch 18, 24 x 200 pts).
-
-Prerequisites:
-  - gh CLI installed and authenticated (gh auth login)
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-  MAX_RETRIES         Number of retry attempts on API failure (default: 10)
-  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Wave (Batch 18, 24 x 200 pts)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=24
-ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 18 (24 x 200 pts) issues with auto-retry..."
+echo "Creating Batch 18 (24 x 200 pts) issues with auto-retry.."
 
 # Alias kept for readability; delegates to the shared helper.
-create_issue_with_retry() { create_issue "$1" "$2" "$3"; }
 
 # ─── 1 ────────────────────────────────────────────────────────────────────────
 create_issue_with_retry "Implement Advanced Thread Tuning for Stellar Core Workloads" "stellar-wave,enhancement,performance" "### 🔴 Difficulty: High (200 Points)

--- a/scripts/archive/create_batch_19_issues.sh
+++ b/scripts/archive/create_batch_19_issues.sh
@@ -1,51 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Wave (Batch 19, 12 x 200 pts).
-
-Prerequisites:
-  - gh CLI installed and authenticated (gh auth login)
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-  MAX_RETRIES         Number of retry attempts on API failure (default: 10)
-  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Wave (Batch 19, 12 x 200 pts)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=12
-ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 19 (12 x 200 pts) issues with auto-retry..."
+echo "Creating Batch 19 (12 x 200 pts) issues with auto-retry.."
 
 # Alias kept for readability; delegates to the shared helper.
-create_issue_with_retry() { create_issue "$1" "$2" "$3"; }
 
 # ─── 1 ────────────────────────────────────────────────────────────────────────
 create_issue_with_retry "Implement Automated Rollback for Failed Validator Upgrades" "stellar-wave,enhancement,reliability" "### 🔴 Difficulty: High (200 Points)

--- a/scripts/archive/create_batch_200point_issues.sh
+++ b/scripts/archive/create_batch_200point_issues.sh
@@ -1,44 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
 # Stellar-K8s Hard (200 Points) Issues Batch - Issues #628-#639
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Hard difficulty batch (200 Points each).
-
-Prerequisites:
-  - gh CLI installed and authenticated
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Hard difficulty batch (200 Points each)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=12
-ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-echo "Creating Batch of 200-point (Hard) Stellar-K8s issues..."
+echo "Creating Batch of 200-point (Hard) Stellar-K8s issues.."
 
 # 628. Multi-region failover and disaster recovery
 gh issue create --repo "$REPO" \

--- a/scripts/archive/create_batch_20_issues.sh
+++ b/scripts/archive/create_batch_20_issues.sh
@@ -1,32 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="OtowoOrg/Stellar-K8s"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-echo "Creating Batch 20 (15x200, 5x150, 5x100 pts) issues..."
-
-function create_issue_with_retry() {
-  local title="$1"
-  local label="$2"
-  local body="$3"
-  
-  local max_retries=5
-  local count=0
-  
-  while [ $count -lt $max_retries ]; do
-    if gh issue create --repo "$REPO" --title "$title" --label "$label" --body "$body"; then
-      echo "✓ Issue created: $title"
-      return 0
-    else
-      count=$((count + 1))
-      echo "API failed, retrying ($count/$max_retries) in 10 seconds..."
-      sleep 10
-    fi
-  done
-  
-  echo "Failed to create issue after $max_retries attempts: $title"
-  exit 1
-}
+echo "Creating Batch 20 (15x200, 5x150, 5x100 pts) issues.."
 
 # --- 200 POINT ISSUES (1-15) ---
 

--- a/scripts/archive/create_batch_21_issues.sh
+++ b/scripts/archive/create_batch_21_issues.sh
@@ -1,32 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="OtowoOrg/Stellar-K8s"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-echo "Creating Batch 21 (20 x 200 pts) issues with auto-retry..."
-
-function create_issue_with_retry() {
-  local title="$1"
-  local label="$2"
-  local body="$3"
-  
-  local max_retries=5
-  local count=0
-  
-  while [ $count -lt $max_retries ]; do
-    if gh issue create --repo "$REPO" --title "$title" --label "$label" --body "$body"; then
-      echo "✓ Issue created: $title"
-      return 0
-    else
-      count=$((count + 1))
-      echo "API failed, retrying ($count/$max_retries) in 10 seconds..."
-      sleep 10
-    fi
-  done
-  
-  echo "Failed to create issue after $max_retries attempts: $title"
-  exit 1
-}
+echo "Creating Batch 21 (20 x 200 pts) issues with auto-retry.."
 
 # --- 200 POINT ISSUES (1-20) ---
 

--- a/scripts/archive/create_batch_22_issues.sh
+++ b/scripts/archive/create_batch_22_issues.sh
@@ -1,32 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="OtowoOrg/Stellar-K8s"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-echo "Creating Batch 22 (20 x 200 pts, 10 x 100 pts) issues..."
-
-function create_issue_with_retry() {
-  local title="$1"
-  local label="$2"
-  local body="$3"
-  
-  local max_retries=5
-  local count=0
-  
-  while [ $count -lt $max_retries ]; do
-    if gh issue create --repo "$REPO" --title "$title" --label "$label" --body "$body"; then
-      echo "✓ Issue created: $title"
-      return 0
-    else
-      count=$((count + 1))
-      echo "API failed, retrying ($count/$max_retries) in 10 seconds..."
-      sleep 10
-    fi
-  done
-  
-  echo "Failed to create issue after $max_retries attempts: $title"
-  exit 1
-}
+echo "Creating Batch 22 (20 x 200 pts, 10 x 100 pts) issues.."
 
 # --- 200 POINT ISSUES (1-20) ---
 

--- a/scripts/archive/create_batch_23_issues.sh
+++ b/scripts/archive/create_batch_23_issues.sh
@@ -1,32 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="OtowoOrg/Stellar-K8s"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-echo "Creating Batch 23 (12 x 100 pts) issues..."
-
-function create_issue_with_retry() {
-  local title="$1"
-  local label="$2"
-  local body="$3"
-  
-  local max_retries=5
-  local count=0
-  
-  while [ $count -lt $max_retries ]; do
-    if gh issue create --repo "$REPO" --title "$title" --label "$label" --body "$body"; then
-      echo "✓ Issue created: $title"
-      return 0
-    else
-      count=$((count + 1))
-      echo "API failed, retrying ($count/$max_retries) in 10 seconds..."
-      sleep 10
-    fi
-  done
-  
-  echo "Failed to create issue after $max_retries attempts: $title"
-  exit 1
-}
+echo "Creating Batch 23 (12 x 100 pts) issues.."
 
 # --- 100 POINT ISSUES (1-12) ---
 

--- a/scripts/archive/create_batch_23_v2_issues.sh
+++ b/scripts/archive/create_batch_23_v2_issues.sh
@@ -1,32 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="OtowoOrg/Stellar-K8s"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-echo "Creating Batch 23 (12 x 100 pts, 8 x 200 pts) issues..."
-
-function create_issue_with_retry() {
-  local title="$1"
-  local label="$2"
-  local body="$3"
-  
-  local max_retries=5
-  local count=0
-  
-  while [ $count -lt $max_retries ]; do
-    if gh issue create --repo "$REPO" --title "$title" --label "$label" --body "$body"; then
-      echo "✓ Issue created: $title"
-      return 0
-    else
-      count=$((count + 1))
-      echo "API failed, retrying ($count/$max_retries) in 10 seconds..."
-      sleep 10
-    fi
-  done
-  
-  echo "Failed to create issue after $max_retries attempts: $title"
-  exit 1
-}
+echo "Creating Batch 23 (12 x 100 pts, 8 x 200 pts) issues.."
 
 # --- 100 POINT ISSUES (1-12) ---
 

--- a/scripts/archive/create_batch_24_cicd_issues.sh
+++ b/scripts/archive/create_batch_24_cicd_issues.sh
@@ -1,42 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s CI/CD passing and deduplication (Hard - 200 Points each).
-
-Prerequisites:
-  - gh CLI installed and authenticated
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s CI/CD passing and deduplication (Hard - 200 Points each)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=4
-ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-echo "Creating Batch of 200-point CI/CD Issues..."
+echo "Creating Batch of 200-point CI/CD Issues.."
 
 # 1. Consolidate Core CI Workflows
 gh issue create --repo "$REPO" \

--- a/scripts/archive/create_batch_25_100pt_issues.sh
+++ b/scripts/archive/create_batch_25_100pt_issues.sh
@@ -1,42 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Medium difficulty batch (100 Points each).
-
-Prerequisites:
-  - gh CLI installed and authenticated
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Medium difficulty batch (100 Points each)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=12
-ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-echo "Creating Batch of 12 Medium (100-point) issues..."
+echo "Creating Batch of 12 Medium (100-point) issues.."
 
 gh issue create --repo "$REPO" \
   --title "Add advanced Liveness and Readiness probes to Stellar-Core nodes" \

--- a/scripts/archive/create_batch_26_200pt_issues.sh
+++ b/scripts/archive/create_batch_26_200pt_issues.sh
@@ -1,42 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Hard difficulty batch (200 Points each).
-
-Prerequisites:
-  - gh CLI installed and authenticated
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Hard difficulty batch (200 Points each)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=8
-ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-echo "Creating Batch of 8 Hard (200-point) issues..."
+echo "Creating Batch of 8 Hard (200-point) issues.."
 
 gh issue create --repo "$REPO" \
   --title "Implement automated cross-region state synchronization" \

--- a/scripts/archive/create_batch_27_200pt_issues.sh
+++ b/scripts/archive/create_batch_27_200pt_issues.sh
@@ -1,42 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Hard difficulty batch 27 (200 Points each).
-
-Prerequisites:
-  - gh CLI installed and authenticated
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Hard difficulty batch 27 (200 Points each)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=15
-ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-echo "Creating Batch 27 of 15 Hard (200-point) issues..."
+echo "Creating Batch 27 of 15 Hard (200-point) issues.."
 
 # Issue 1: Advanced Network Policy Enforcement
 gh issue create --repo "$REPO" \

--- a/scripts/archive/create_batch_28_200pt_docs_issues.sh
+++ b/scripts/archive/create_batch_28_200pt_docs_issues.sh
@@ -1,42 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Hard difficulty documentation batch (200 Points each).
-
-Prerequisites:
-  - gh CLI installed and authenticated
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Hard difficulty documentation batch (200 Points each)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=4
-ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-echo "Creating Batch 28 of 4 Hard (200-point) documentation issues..."
+echo "Creating Batch 28 of 4 Hard (200-point) documentation issues.."
 
 # Issue 1: Comprehensive Architecture Documentation
 gh issue create --repo "$REPO" \

--- a/scripts/archive/create_batch_28_200pt_issues.sh
+++ b/scripts/archive/create_batch_28_200pt_issues.sh
@@ -1,43 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Hard difficulty batch 28 (200 Points each).
-These are simpler 200-point issues focused on specific, well-defined features.
-
-Prerequisites:
-  - gh CLI installed and authenticated
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Hard difficulty batch 28 (200 Points each)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=12
-ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-echo "Creating Batch 28 of 12 Hard (200-point) issues (simpler scope)..."
+echo "Creating Batch 28 of 12 Hard (200-point) issues (simpler scope).."
 
 # Issue 1: Custom Resource Status Conditions
 gh issue create --repo "$REPO" \

--- a/scripts/archive/create_batch_29_epic_issues.sh
+++ b/scripts/archive/create_batch_29_epic_issues.sh
@@ -1,43 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates 12 GitHub EPIC issues (200 Points each) for Stellar-K8s.
-These are major architectural features requiring significant effort.
-
-Prerequisites:
-  - gh CLI installed and authenticated
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=12
-ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-echo "Creating Batch of 12 EPIC (200-point) issues..."
+echo "Creating Batch of 12 EPIC (200-point) issues.."
 
 # EPIC 1: Multi-Region Federation
 gh issue create --repo "$REPO" \

--- a/scripts/archive/create_batch_2_issues.sh
+++ b/scripts/archive/create_batch_2_issues.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
 # Stellar-K8s Wave Issue Creation Script - BATCH 2
 # Issues #12 - #21
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 2 of Stellar Wave issues..."
+echo "Creating Batch 2 of Stellar Wave issues.."
 
 # 12. Add Resource Limit validation (Trivial - 100 Points)
 create_issue \

--- a/scripts/archive/create_batch_30_epic_issues.sh
+++ b/scripts/archive/create_batch_30_epic_issues.sh
@@ -1,43 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates 12 additional GitHub EPIC issues (200 Points each) for Stellar-K8s.
-These are major architectural features requiring significant effort.
-
-Prerequisites:
-  - gh CLI installed and authenticated
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=12
-ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-echo "Creating Batch 30 of 12 EPIC (200-point) issues..."
+echo "Creating Batch 30 of 12 EPIC (200-point) issues.."
 
 # EPIC 13: Service Mesh Integration
 gh issue create --repo "$REPO" \

--- a/scripts/archive/create_batch_3_issues.sh
+++ b/scripts/archive/create_batch_3_issues.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
 # Stellar-K8s Wave Issue Creation Script - BATCH 3 (High Complexity)
 # Issues #22 - #24
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 3 (200 points) issues..."
+echo "Creating Batch 3 (200 points) issues.."
 
 # 22. Automated PVC Snapshots/Backups (High - 200 Points)
 create_issue \

--- a/scripts/archive/create_batch_4_issues.sh
+++ b/scripts/archive/create_batch_4_issues.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
 # Stellar-K8s Wave Issue Creation Script - BATCH 4
 # 6 High (200 pts), 2 Medium (150 pts), 2 Trivial (100 pts)
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 4 (Mixed) issues..."
+echo "Creating Batch 4 (Mixed) issues.."
 
 # --- HIGH (200 pts) ---
 

--- a/scripts/archive/create_batch_5_issues.sh
+++ b/scripts/archive/create_batch_5_issues.sh
@@ -1,21 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
 # Stellar-K8s Wave Issue Creation Script - BATCH 5
 # 3 High (200 pts), 4 Medium (150 pts), 3 Trivial (100 pts)
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
 # Helper to create label if not exists
 create_label() {
   gh label create --repo "$REPO" "$1" --color "$2" --description "$3" || true
 }
 
-echo "Ensuring labels exist..."
+echo "Ensuring labels exist.."
 create_label "stellar-wave" "1d76db" "Stellar Wave Program"
 create_label "good-first-issue" "7057ff" "Good for newcomers"
 create_label "rust" "DEA584" "Rust related"
@@ -29,7 +27,7 @@ create_label "reliability" "d93f0b" "Reliability and stability"
 create_label "architecture" "0e8a16" "Architecture design"
 create_label "documentation" "0075ca" "Improvements or additions to documentation"
 
-echo "Creating Batch 5 (Advanced) issues..."
+echo "Creating Batch 5 (Advanced) issues.."
 
 # --- HIGH (200 pts) ---
 

--- a/scripts/archive/create_batch_6_issues.sh
+++ b/scripts/archive/create_batch_6_issues.sh
@@ -1,21 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
 # Stellar-K8s Wave Issue Creation Script - BATCH 6
 # 10 Elite Engineering Issues (200 pts each)
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
 # Helper to create label if not exists
 create_label() {
   gh label create --repo "$REPO" "$1" --color "$2" --description "$3" || true
 }
 
-echo "Ensuring labels exist..."
+echo "Ensuring labels exist.."
 create_label "stellar-wave" "1d76db" "Stellar Wave Program"
 create_label "architecture" "0e8a16" "Architecture design"
 create_label "reliability" "d93f0b" "Reliability and stability"
@@ -24,7 +22,7 @@ create_label "kubernetes" "326ce5" "Kubernetes related"
 create_label "performance" "bfd4f2" "Performance optimizations"
 create_label "automation" "ffb3b3" "Automated workflows"
 
-echo "Creating Batch 6 (Elite) issues..."
+echo "Creating Batch 6 (Elite) issues.."
 
 # 1. Cross-Region Multi-Cluster Disaster Recovery (High - 200 pts)
 create_issue \

--- a/scripts/archive/create_batch_7_issues.sh
+++ b/scripts/archive/create_batch_7_issues.sh
@@ -1,53 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Wave (Batch 7, 20 x 200 pts).
-
-Prerequisites:
-  - gh CLI installed and authenticated (gh auth login)
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-  MAX_RETRIES         Number of retry attempts on API failure (default: 10)
-  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Wave (Batch 7, 20 x 200 pts)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=20
-ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Ensuring required labels exist..."
+echo "Ensuring required labels exist.."
 for label in "stellar-wave" "testing" "documentation" "ci" "bug" "enhancement" "good-first-issue" "security" "performance" "reliability" "kubernetes" "observability" "dx"; do
   gh label create --repo "$REPO" "$label" --color "0075ca" 2>/dev/null || true
 done
 
-echo "Creating Batch 7 issues..."
+echo "Creating Batch 7 issues.."
 
 create_issue \
   "Verify: Operator binary boots and connects to a live cluster without errors" \

--- a/scripts/archive/create_batch_8_issues.sh
+++ b/scripts/archive/create_batch_8_issues.sh
@@ -1,48 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Wave (Batch 8, 10 x 200 pts).
-
-Prerequisites:
-  - gh CLI installed and authenticated (gh auth login)
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-  MAX_RETRIES         Number of retry attempts on API failure (default: 10)
-  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Wave (Batch 8, 10 x 200 pts)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=10
-ACTUAL_ISSUE_COUNT=$(grep -c '^gh issue create' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Creating Batch 8 (10 x 200 pts) issues..."
+echo "Creating Batch 8 (10 x 200 pts) issues.."
 
 create_issue \
   "Add comprehensive unit tests for the main reconciler loop" \

--- a/scripts/archive/create_batch_9_issues.sh
+++ b/scripts/archive/create_batch_9_issues.sh
@@ -1,51 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-show_help() {
-  cat <<EOF
-Usage: $(basename "$0") [-h|--help]
-
-Creates GitHub issues for Stellar-K8s Wave (Batch 9, final 3 issues).
-
-Prerequisites:
-  - gh CLI installed and authenticated (gh auth login)
-  - Network access to api.github.com
-
-Optional environment variables:
-  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
-  DRY_RUN             Set to 1 to print commands without executing
-  MAX_RETRIES         Number of retry attempts on API failure (default: 10)
-  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
-
-Example:
-  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
-EOF
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) show_help; exit 0 ;;
-  esac
-done
+BATCH_HELP_DESC="Creates GitHub issues for Stellar-K8s Wave (Batch 9, final 3 issues)."
+batch_parse_help "$@"
 
 EXPECTED_ISSUE_COUNT=3
-ACTUAL_ISSUE_COUNT=$(grep -c '^create_issue_with_retry' "$0")
-if [ "$ACTUAL_ISSUE_COUNT" -ne "$EXPECTED_ISSUE_COUNT" ]; then
-  echo "ERROR: Expected $EXPECTED_ISSUE_COUNT issue create calls, found $ACTUAL_ISSUE_COUNT. Update EXPECTED_ISSUE_COUNT or fix the script." >&2
-  exit 1
-fi
+batch_validate_issue_count "$EXPECTED_ISSUE_COUNT"
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
-echo "Resuming Batch 9 (final 3 issues)..."
+echo "Resuming Batch 9 (final 3 issues).."
 
 # Alias kept for readability; delegates to the shared helper.
-create_issue_with_retry() { create_issue "$1" "$2" "$3"; }
 
 # ─── ISSUE 5 ───────────────────────────────────────────────────────────────────
 create_issue_with_retry \

--- a/scripts/archive/create_labels.sh
+++ b/scripts/archive/create_labels.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
 # Create all necessary labels for Stellar Wave issues
 # Uses || true to ignore errors if label already exists
 
-echo "Creating labels..."
+echo "Creating labels.."
 
 gh label create --repo "$REPO" rust --color DEA584 --description "Rust related" || true
 gh label create --repo "$REPO" soroban --color 7F129E --description "Soroban smart contracts" || true
@@ -66,7 +66,7 @@ if [[ "${1:-}" == "--source-only" ]]; then
   return 0 2>/dev/null || exit 0
 fi
 
-echo "Creating labels..."
+echo "Creating labels.."
 
 gh label create "$LABEL_RUST"          --color DEA584 --description "Rust related"              || true
 gh label create "$LABEL_SOROBAN"       --color 7F129E --description "Soroban smart contracts"    || true

--- a/scripts/archive/create_wave_issues.sh
+++ b/scripts/archive/create_wave_issues.sh
@@ -1,21 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
 # Stellar-K8s Wave Issue Creation Script
 # Uses gh CLI to create issues defined in WAVE_ISSUES.md
 
-# Source shared retry/backoff and dry-run helper.
-# shellcheck source=lib/common.sh
 
 # Helper to create label if not exists
 create_label() {
   gh label create --repo "$REPO" "$1" --color "$2" --description "$3" || true
 }
 
-echo "Ensuring labels exist..."
+echo "Ensuring labels exist.."
 create_label "stellar-wave" "1d76db" "Stellar Wave Program"
 create_label "good-first-issue" "7057ff" "Good for newcomers"
 create_label "testing" "C2E0C6" "Tests"
@@ -32,7 +30,7 @@ create_label "soroban" "7F129E" "Soroban smart contracts"
 create_label "reliability" "d93f0b" "Reliability and stability"
 create_label "architecture" "0e8a16" "Architecture design"
 
-echo "Creating Stellar Wave issues..."
+echo "Creating Stellar Wave issues.."
 
 # 1. Add unit tests for StellarNodeSpec validation
 create_issue \

--- a/scripts/archive/update_epic_issues.sh
+++ b/scripts/archive/update_epic_issues.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="${REPO:-OtowoOrg/Stellar-K8s}"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
-echo "Updating epic issues to remove 'Estimated Effort' sections..."
+echo "Updating epic issues to remove 'Estimated Effort' sections.."
 
 # Get all epic issues
 ISSUE_NUMBERS=(871 870 869 868 867 866 865 864 863 862 861 860)
 
 for issue_num in "${ISSUE_NUMBERS[@]}"; do
-  echo "Processing issue #$issue_num..."
+  echo "Processing issue #$issue_num.."
   
   # Get current issue body
   body=$(gh issue view "$issue_num" --repo "$REPO" --json body -q .body)

--- a/scripts/archive/update_wave_issues.sh
+++ b/scripts/archive/update_wave_issues.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=lib/common.sh
-source "$(dirname "$0")/lib/common.sh"
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
 
 # Update Stellar Wave Issues with Points, Criteria, and Resources
 # Updates issues #2 through #11
 
-echo "Updating Stellar Wave issues..."
+echo "Updating Stellar Wave issues.."
 
 # Issue 2: Unit Tests (Trivial - 100 Points)
 gh issue edit 2 --repo "$REPO" \

--- a/scripts/lib/batch.sh
+++ b/scripts/lib/batch.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# scripts/lib/batch.sh
+# Shared helpers for archived batch issue-creation scripts.
+#
+# Usage (from scripts/archive/*.sh):
+#   source "$(dirname "$0")/../lib/batch.sh"
+#   BATCH_HELP_DESC="Creates GitHub issues for batch N."
+#   batch_parse_help "$@"
+#   batch_validate_issue_count "${EXPECTED_ISSUE_COUNT:-0}"
+
+# shellcheck source=common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+# batch_show_help [description]
+#   Print standard usage text. Set BATCH_HELP_DESC before calling batch_parse_help.
+batch_show_help() {
+  local description="${1:-${BATCH_HELP_DESC:-Creates GitHub issues for Stellar-K8s.}}"
+  cat <<EOF
+Usage: $(basename "$0") [-h|--help]
+
+${description}
+
+Prerequisites:
+  - gh CLI installed and authenticated (gh auth login)
+  - Network access to api.github.com
+
+Optional environment variables:
+  REPO                Target repository (default: OtowoOrg/Stellar-K8s)
+  DRY_RUN             Set to true or 1 to print commands without executing
+  RETRY_MAX_ATTEMPTS  Number of retry attempts on API failure (default: 10)
+  RETRY_DELAY_SECONDS Seconds to wait between retries (default: 15)
+
+Example:
+  REPO=myorg/my-fork DRY_RUN=1 $(basename "$0")
+EOF
+}
+
+# batch_parse_help "$@"
+#   Exit 0 after printing help when -h/--help is passed.
+batch_parse_help() {
+  for arg in "$@"; do
+    case "$arg" in
+      -h | --help)
+        batch_show_help "${BATCH_HELP_DESC:-Creates GitHub issues for Stellar-K8s.}"
+        exit 0
+        ;;
+    esac
+  done
+}
+
+# batch_validate_issue_count <expected> [script_path]
+#   Sanity-check that the script contains the expected number of issue calls.
+batch_validate_issue_count() {
+  local expected="$1"
+  local script="${2:-$0}"
+  local actual
+
+  actual=$(grep -cE '^[[:space:]]*(create_issue|create_issue_with_retry|gh issue create)' "$script" || true)
+  if [[ "$actual" -ne "$expected" ]]; then
+    echo "ERROR: Expected ${expected} issue create calls, found ${actual} in ${script}." >&2
+    echo "  Hint: Update EXPECTED_ISSUE_COUNT or fix the script." >&2
+    exit 1
+  fi
+}
+
+# create_issue_with_retry — backward-compatible alias used by archived batch scripts.
+create_issue_with_retry() {
+  create_issue "$1" "$2" "$3"
+}

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -2,6 +2,12 @@
 # scripts/lib/common.sh
 # Shared utilities: repository resolution, dry-run parsing, and retry logic.
 
+# ── Dry-Run Normalization ───────────────────────────────────────────────────
+# Accept common truthy values used across batch scripts (1, true, yes).
+case "${DRY_RUN:-}" in
+  1 | true | TRUE | yes | YES) export DRY_RUN=true ;;
+esac
+
 # ── Repository Resolution ───────────────────────────────────────────────────
 _DEFAULT_REPO="OtowoOrg/Stellar-K8s"
 export REPO="${REPO:-$_DEFAULT_REPO}"

--- a/scripts/tests/common.bats
+++ b/scripts/tests/common.bats
@@ -10,7 +10,7 @@ setup() {
 
   # Source the common helper script
   source "${BATS_TEST_DIRNAME}/../lib/common.sh"
-  
+
   # Mock gh command
   gh() {
     if [[ "$1" == "issue" && "$2" == "create" ]]; then
@@ -27,7 +27,15 @@ setup() {
 @test "dry_run mode prints and does not fail" {
   export DRY_RUN="true"
   run create_issue "Test Title" "bug" "Test Body"
-  
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[DRY RUN] title:  Test Title"* ]]
+}
+
+@test "dry_run accepts numeric truthy value 1" {
+  export DRY_RUN="1"
+  run create_issue "Test Title" "bug" "Test Body"
+
   [ "$status" -eq 0 ]
   [[ "$output" == *"[DRY RUN] title:  Test Title"* ]]
 }
@@ -35,7 +43,7 @@ setup() {
 @test "create_issue succeeds on first try" {
   export GH_MOCK_SHOULD_FAIL="false"
   run create_issue "Test Title" "bug" "Test Body"
-  
+
   [ "$status" -eq 0 ]
   [[ "$output" == *"✓ Issue created: Test Title"* ]]
 }
@@ -44,7 +52,7 @@ setup() {
   export GH_MOCK_SHOULD_FAIL="true"
   export RETRY_MAX_ATTEMPTS=2
   run create_issue "Test Title" "bug" "Test Body"
-  
+
   [ "$status" -eq 1 ]
   [[ "$output" == *"ERROR: Failed to create issue after 2 attempts: Test Title"* ]]
 }
@@ -52,7 +60,35 @@ setup() {
 @test "REPO validation fails on invalid format" {
   export REPO="Invalid/Repo/Format"
   run bash -c "source ${BATS_TEST_DIRNAME}/../lib/common.sh"
-  
+
   [ "$status" -eq 1 ]
   [[ "$output" == *"ERROR [validate repo]: REPO='Invalid/Repo/Format' is not a valid 'owner/name' format."* ]]
+}
+
+@test "batch_validate_issue_count passes when counts match" {
+  source "${BATS_TEST_DIRNAME}/../lib/batch.sh"
+  run bash -c '
+    source "'"${BATS_TEST_DIRNAME}"'/../lib/batch.sh"
+    EXPECTED_ISSUE_COUNT=2
+    batch_validate_issue_count "$EXPECTED_ISSUE_COUNT" "'"${BATS_TEST_DIRNAME}"'/fixtures/two_issues.sh"
+  '
+  [ "$status" -eq 0 ]
+}
+
+@test "batch_validate_issue_count fails when counts mismatch" {
+  run bash -c '
+    source "'"${BATS_TEST_DIRNAME}"'/../lib/batch.sh"
+    batch_validate_issue_count 5 "'"${BATS_TEST_DIRNAME}"'/fixtures/two_issues.sh"
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Expected 5 issue create calls, found 2"* ]]
+}
+
+@test "create_issue_with_retry delegates to create_issue" {
+  export DRY_RUN="true"
+  source "${BATS_TEST_DIRNAME}/../lib/batch.sh"
+  run create_issue_with_retry "Alias Title" "bug" "Alias Body"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[DRY RUN] title:  Alias Title"* ]]
 }

--- a/scripts/tests/fixtures/two_issues.sh
+++ b/scripts/tests/fixtures/two_issues.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source=../lib/batch.sh
+source "$(dirname "$0")/../lib/batch.sh"
+
+create_issue "First" "bug" "body one"
+create_issue_with_retry "Second" "bug" "body two"


### PR DESCRIPTION
## Summary

- Added `scripts/lib/batch.sh` with shared `--help` output, issue-count validation, and `create_issue_with_retry` alias
- Fixed archived batch scripts to source `../lib/batch.sh` (previous paths pointed at a non-existent `scripts/archive/lib/`)
- Normalized `DRY_RUN` handling in `scripts/lib/common.sh` to accept `1`, `true`, and `yes`
- Removed per-script duplicate `show_help` blocks and local retry wrappers that only delegated to `create_issue`
- Added `make test-shell` and bats coverage in `scripts/tests/common.bats`

Closes #1003

## Shell helper consolidation

All `scripts/archive/create_batch_*.sh` scripts now share one library stack:

| File | Responsibility |
|------|----------------|
| `scripts/lib/common.sh` | Repo resolution, dry-run, retrying `create_issue` |
| `scripts/lib/batch.sh` | Help text, issue-count guard, backward-compatible alias |

## Removed scripts/wrappers summary

No scripts removed in this PR — duplication was consolidated in place.

## Documentation updates

- Updated `scripts/archive/README.md` with shared helper usage

## Test coverage summary

- `scripts/tests/common.bats`: dry-run modes, retry failure, REPO validation, batch count validation, alias delegation
- `make test-shell` target added to Makefile

## Validation results

- Batch script dry-run verified: `DRY_RUN=true bash scripts/archive/create_batch_2_issues.sh`
- Shell helper behavior preserved (same `create_issue` / `gh issue create` calls, now via shared library)

## Test plan

- [x] `DRY_RUN=true` batch script smoke test
- [ ] `make test-shell` (requires bats)
- [ ] CI green

Made with [Cursor](https://cursor.com)