### PR TITLE
[673] Add support for custom init containers in node deployments

### DIFF
--- a/config/crd/stellarnode-crd.yaml
+++ b/config/crd/stellarnode-crd.yaml
@@ -658,6 +658,17 @@ spec:
                 required:
                 - hosts
                 type: object
+              initContainers:
+                description: |-
+                  Optional init containers to run before the main Stellar container starts.
+                  These run to completion in order before the main container starts.
+                  Useful for tasks like fetching custom configuration, restoring state,
+                  or pre-populating volumes.
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                nullable: true
+                type: array
               loadBalancer:
                 description: Load balancer configuration for external access (e.g. MetalLB)
                 nullable: true

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1100,6 +1100,18 @@ Fields marked *(required)* must be present in every `StellarNode` manifest.
 | **Type** | `string` |
 | **Nullable** | `true` |
 
+### `spec.initContainers`
+
+| | |
+|---|---|
+| **Path** | `spec.initContainers` |
+| **Type** | `array` of `object` |
+| **Description** | Optional init containers to run before the main Stellar container starts.
+These run to completion in order before the main container starts.
+Useful for tasks like fetching custom configuration, restoring state,
+or pre-populating volumes. |
+| **Nullable** | `true` |
+
 ### `spec.loadBalancer`
 
 | | |


### PR DESCRIPTION
## Summary

- Adds `spec.initContainers` to the StellarNode CRD OpenAPI schema (`config/crd/stellarnode-crd.yaml`)
- Operator StatefulSet/Deployment generation and unit tests for injection were already present; this closes the API schema gap

Closes #673

## Init container CRD changes

```yaml
spec:
  initContainers:
    - name: fetch-config
      image: curlimages/curl:latest
      volumeMounts:
        - name: data
          mountPath: /data
```

The schema uses `x-kubernetes-preserve-unknown-fields` on array items to accept standard Kubernetes `Container` objects.

## Restart strategy explanation

User-provided init containers run to completion before the main Stellar container starts. Operator-managed init containers (migrations, snapshot restore) are appended first; user containers follow.

## Test coverage summary

Existing coverage (unchanged in this PR):
- `src/controller/resources_test.rs` — StatefulSet/Deployment injection tests
- `tests/init_containers_test.rs` — ordering and validation scenarios

## Validation results

- CRD schema now documents `initContainers` field present in Rust types since #710

## Test plan

- [x] CRD schema includes `initContainers`
- [ ] `cargo test init_containers` (existing tests)
- [ ] CI green

Made with [Cursor](https://cursor.com)