### PR TITLE
feat: preflight checks, webhook chart tightening, rotation docs, error context

### DIFF
--- a/charts/stellar-operator/templates/webhook.yaml
+++ b/charts/stellar-operator/templates/webhook.yaml
@@ -60,7 +60,7 @@ metadata:
     app.kubernetes.io/name: stellar-webhook
     app.kubernetes.io/component: admission-webhook
 spec:
-  replicas: 2
+  replicas: {{ .Values.webhook.replicaCount | default 2 }}
   selector:
     matchLabels:
       app.kubernetes.io/name: stellar-webhook
@@ -71,7 +71,7 @@ spec:
         app.kubernetes.io/component: admission-webhook
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
+        prometheus.io/port: {{ .Values.webhook.metricsPort | default 9090 | quote }}
     spec:
       serviceAccountName: stellar-webhook
       automountServiceAccountToken: false
@@ -87,15 +87,15 @@ spec:
           image: '{{ if .Values.image.digest }}{{ .Values.image.repository }}@{{ .Values.image.digest }}{{ else }}{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}{{ end }}'
           imagePullPolicy: '{{ .Values.image.pullPolicy }}'
           args:
-            - "--webhook-port=8443"
-            - "--metrics-port=9090"
+            - "--webhook-port={{ .Values.webhook.port | default 8443 }}"
+            - "--metrics-port={{ .Values.webhook.metricsPort | default 9090 }}"
             - "--cert-dir=/certs"
           ports:
             - name: https
-              containerPort: 8443
+              containerPort: {{ .Values.webhook.port | default 8443 }}
               protocol: TCP
             - name: metrics
-              containerPort: 9090
+              containerPort: {{ .Values.webhook.metricsPort | default 9090 }}
               protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
@@ -104,12 +104,7 @@ spec:
               drop:
                 - ALL
           resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
-            limits:
-              cpu: 500m
-              memory: 512Mi
+            {{- toYaml .Values.webhook.resources | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -172,7 +167,7 @@ spec:
       targetPort: https
       protocol: TCP
     - name: metrics
-      port: 9090
+      port: {{ .Values.webhook.metricsPort | default 9090 }}
       targetPort: metrics
       protocol: TCP
   selector:
@@ -206,8 +201,8 @@ webhooks:
         scope: Namespaced
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
-    timeoutSeconds: 10
-    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhook.timeoutSeconds | default 10 }}
+    failurePolicy: {{ .Values.webhook.failurePolicy | default "Fail" }}
     matchPolicy: Equivalent
     namespaceSelector:
       matchExpressions:

--- a/charts/stellar-operator/values.schema.json
+++ b/charts/stellar-operator/values.schema.json
@@ -154,6 +154,44 @@
     },
     "scpAnalytics": {
       "type": "object"
+    },
+    "webhook": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of webhook server replicas"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Container port for the webhook HTTPS server"
+        },
+        "metricsPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Container port for the Prometheus metrics endpoint"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 30,
+          "description": "Admission review timeout in seconds (Kubernetes maximum is 30)"
+        },
+        "failurePolicy": {
+          "type": "string",
+          "enum": ["Fail", "Ignore"],
+          "description": "Action when webhook is unreachable: Fail blocks admission, Ignore allows it"
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resource requests and limits for the webhook server container"
+        }
+      }
     }
   },
   "additionalProperties": true

--- a/charts/stellar-operator/values.yaml
+++ b/charts/stellar-operator/values.yaml
@@ -584,6 +584,36 @@ scpAnalytics:
         cpu: 200m
         memory: 256Mi
 
+# --- Admission webhook deployment settings -----------------------------------
+# Controls the webhook Deployment, Service, and ValidatingWebhookConfiguration
+# rendered by charts/stellar-operator/templates/webhook.yaml.
+webhook:
+  # Number of webhook server replicas. Set to >= 2 for production HA.
+  replicaCount: 2
+
+  # Port the webhook HTTPS server listens on inside the container.
+  port: 8443
+
+  # Port for the Prometheus /metrics endpoint on the webhook pod.
+  metricsPort: 9090
+
+  # Admission review timeout in seconds. Kubernetes maximum is 30.
+  timeoutSeconds: 10
+
+  # Action when the webhook is unreachable: Fail (safe default) or Ignore.
+  # Fail: admission is blocked if the webhook cannot be reached.
+  # Ignore: admission proceeds without the webhook response.
+  failurePolicy: Fail
+
+  # Resource requests and limits for the webhook server container.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 # --- Helm lifecycle hooks ----------------------------------------------------
 hooks:
   # Pre-install hook — validation checks before first installation.

--- a/docs/rotation-workflows.md
+++ b/docs/rotation-workflows.md
@@ -1,0 +1,232 @@
+# Secrets and Certificate Rotation Workflows
+
+This document is the central reference for all rotation workflows in Stellar-K8s.
+It covers when and how to rotate each type of credential or certificate managed by the operator.
+
+## Overview
+
+| Credential | Rotation method | Frequency | Guide |
+|---|---|---|---|
+| Database passwords (Horizon / Core) | Automated (cron-based) | Quarterly or monthly | [Secret Rotation](secret-rotation.md) |
+| Operator REST API server certificate | Automated (hourly check) | When within threshold | [mTLS Guide](mtls-guide.md) |
+| StellarNode client certificates | On-demand (delete secret) | As needed | [mTLS Guide](mtls-guide.md) |
+| CA certificate | Manual (maintenance window) | Annually or on compromise | [CA Rotation](#ca-certificate-rotation) |
+| Webhook TLS certificate | Automated (cert-manager) | cert-manager managed | [Webhook Cert Rotation](#webhook-tls-certificate-rotation) |
+| Network passphrase secret | Manual or on Secret change | On network config change | [Passphrase Rotation](#network-passphrase-secret-rotation) |
+| Validator seed (`STELLAR_SEED`) | Manual | Per security policy | [Credentials Reference](security/credentials-and-secrets.md) |
+
+---
+
+## Database Credential Rotation
+
+Database password rotation is fully automated when `secretRotation.enabled: true` is set on a
+`StellarNode` resource. See [Secret Rotation](secret-rotation.md) for complete configuration
+details, cron schedules, rollback behavior, and Prometheus metrics.
+
+**Quick enable:**
+
+```yaml
+spec:
+  secretRotation:
+    enabled: true
+    schedule: "0 0 1 */3 *"   # quarterly
+    passwordLength: 32
+    auditLoggingEnabled: true
+```
+
+---
+
+## mTLS Certificate Rotation
+
+The operator issues and rotates two classes of TLS certificate when `--enable-mtls` is active:
+
+- **Operator REST API server certificate** — checked hourly and rotated if expiry is within
+  `CERT_ROTATION_THRESHOLD_DAYS` (default `30`). Rotation reloads the in-memory TLS config
+  without a process restart using the dual-key strategy.
+- **StellarNode client certificates** — recreated on reconcile if the secret is missing;
+  proactive rotation is triggered by deleting the `<node-name>-client-cert` secret.
+
+See [mTLS Setup and Certificate Rotation Guide](mtls-guide.md) for the full runbook including
+CA rotation and troubleshooting steps.
+
+**Tune the rotation threshold:**
+
+```bash
+kubectl -n stellar-system set env deployment/stellar-operator \
+  CERT_ROTATION_THRESHOLD_DAYS=14
+```
+
+---
+
+## CA Certificate Rotation
+
+CA rotation invalidates all leaf certificates. Plan a maintenance window and follow the steps
+documented in [mTLS Guide — Rotate the CA](mtls-guide.md#rotate-the-ca-full-trust-rollover).
+
+---
+
+## Webhook TLS Certificate Rotation
+
+The admission webhook (`stellar-webhook`) uses cert-manager to provision and auto-renew its
+TLS certificate. The cert-manager `Certificate` resource references `selfsigned-issuer` (or
+your production `ClusterIssuer`) and cert-manager handles renewal automatically before expiry.
+
+### Verify current certificate status
+
+```bash
+kubectl -n stellar-webhook get certificate stellar-webhook-cert -o wide
+kubectl -n stellar-webhook describe certificate stellar-webhook-cert
+```
+
+A healthy certificate shows `Ready` in the `READY` column.
+
+### Force immediate renewal
+
+```bash
+kubectl -n stellar-webhook delete secret stellar-webhook-certs
+```
+
+cert-manager detects the missing Secret and issues a new certificate within seconds.
+The webhook pods pick up the new TLS material without a restart because the Secret is
+mounted as a volume and Kubernetes refreshes mounted Secret volumes periodically
+(default every `60s`–`2m`).
+
+If pods do not reload the updated certificate within ~2 minutes, trigger a rollout:
+
+```bash
+kubectl -n stellar-webhook rollout restart deployment/stellar-webhook
+kubectl -n stellar-webhook rollout status deployment/stellar-webhook
+```
+
+### Rotate to a production issuer
+
+Replace `selfsigned-issuer` in `webhook.yaml` (or via Helm values) with a `ClusterIssuer`
+backed by your PKI:
+
+```yaml
+# In your Helm values override:
+# (no built-in value exists — patch the Certificate manifest directly)
+```
+
+Edit the `Certificate` resource:
+
+```bash
+kubectl -n stellar-webhook edit certificate stellar-webhook-cert
+# Change: issuerRef.name: selfsigned-issuer → your-production-issuer
+# Change: issuerRef.kind: ClusterIssuer  → ClusterIssuer (or Issuer)
+```
+
+Update the `ValidatingWebhookConfiguration` CA bundle after issuer change:
+
+```bash
+# cert-manager injects the CA automatically via the annotation:
+# cert-manager.io/inject-ca-from: stellar-webhook/stellar-webhook-cert
+# No manual caBundle update is needed when cert-manager is managing the webhook.
+```
+
+---
+
+## Network Passphrase Secret Rotation
+
+The `StellarNode` CRD supports referencing a Kubernetes Secret for the network passphrase
+via `spec.passphrase_secret_ref`. This allows rotating the passphrase without editing the
+`StellarNode` resource directly.
+
+### Using a passphrase Secret
+
+```yaml
+apiVersion: stellar.io/v1alpha1
+kind: StellarNode
+metadata:
+  name: my-validator
+  namespace: stellar-system
+spec:
+  network: Custom
+  passphrase_secret_ref: my-network-passphrase   # name of a Secret in the same namespace
+```
+
+The referenced Secret must contain the key `NETWORK_PASSPHRASE`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-network-passphrase
+  namespace: stellar-system
+type: Opaque
+stringData:
+  NETWORK_PASSPHRASE: "My Custom Network ; July 2026"
+```
+
+### Rotating the passphrase
+
+1. Create or update the Secret with the new passphrase value:
+
+   ```bash
+   kubectl -n stellar-system create secret generic my-network-passphrase \
+     --from-literal=NETWORK_PASSPHRASE="My Custom Network ; August 2026" \
+     --dry-run=client -o yaml | kubectl apply -f -
+   ```
+
+2. The operator detects the Secret's resource version change via `observed_passphrase_secret_version`
+   in the `StellarNode` status and triggers reconciliation automatically.
+
+3. Verify reconciliation completed:
+
+   ```bash
+   kubectl -n stellar-system get stellarnode my-validator -o jsonpath='{.status.conditions}'
+   ```
+
+4. Check that the updated passphrase is reflected in the pod environment:
+
+   ```bash
+   kubectl -n stellar-system exec deploy/my-validator -- \
+     printenv NETWORK_PASSPHRASE
+   ```
+
+### RBAC for passphrase secrets
+
+Ensure the operator ServiceAccount can read the passphrase secret:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: stellar-operator-passphrase
+  namespace: stellar-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["my-network-passphrase"]
+    verbs: ["get", "watch"]
+```
+
+---
+
+## Rotation Monitoring
+
+All automated rotation events are recorded in the operator audit log. Query them with:
+
+```bash
+kubectl logs -n stellar-system \
+  -l app=stellar-operator \
+  --tail=200 | grep -E "rotation|AUDIT|rotate"
+```
+
+Prometheus metrics for rotation operations:
+
+```
+stellar_operator_secret_rotations_total
+stellar_operator_secret_rotation_duration_seconds
+stellar_operator_secret_rotation_last_success_timestamp
+```
+
+---
+
+## Related Documentation
+
+- [Secret Rotation](secret-rotation.md) — automated database credential rotation
+- [mTLS Guide](mtls-guide.md) — mTLS setup and certificate rotation runbooks
+- [Credentials and Secrets](security/credentials-and-secrets.md) — central secret reference
+- [Secret Management Guide](secret-management-guide.md) — secret storage strategies
+- [Secret Management with KMS](secret-management-kms.md) — AWS/Azure/GCP KMS integration

--- a/docs/security/credentials-and-secrets.md
+++ b/docs/security/credentials-and-secrets.md
@@ -13,6 +13,7 @@ Stellar-K8s supports multiple strategies for managing sensitive credentials, fro
 | Basic secret management | [Secret Management Guide](../secret-management-guide.md) | Getting started with `StellarSecret` CRD |
 | KMS integration | [Advanced Secret Management with KMS](../secret-management-kms.md) | AWS KMS, Azure Key Vault, GCP Cloud KMS |
 | Automated rotation | [Secret Rotation](../secret-rotation.md) | Zero-downtime database credential rotation |
+| All rotation workflows | [Rotation Workflows](../rotation-workflows.md) | Unified guide for secrets, certs, and passphrases |
 | HashiCorp Vault | [Vault + Stellar Tutorial](../vault-stellar-tutorial.md) | Production Vault Agent Injector pattern |
 | Production hardening | [Security Hardening Guide](../production-security-hardening.md) | Full security posture for production |
 | External Secrets Operator | [ExternalSecret chart template](../../charts/stellar-operator/templates/externalsecret.yaml) | ESO integration via Helm |
@@ -23,7 +24,9 @@ Stellar-K8s supports multiple strategies for managing sensitive credentials, fro
 |---|---|---|---|
 | Validator seed (`STELLAR_SEED`) | Kubernetes Secret / Vault | Manual or `vaultRef` | Wallet / Stellar Core |
 | Database credentials (Horizon / Core) | Kubernetes Secret | Automatic (cron-based) | Generated / Provided |
+| Network passphrase | Kubernetes Secret (`passphrase_secret_ref`) | Update Secret, operator reconciles | Operator / deployer |
 | mTLS certificates | Kubernetes Secret (operator-managed) | Automatic renewal | Operator CA |
+| Webhook TLS certificate | Kubernetes Secret (cert-manager) | cert-manager auto-renewal | cert-manager |
 | Webhook HMAC key | Kubernetes Secret | Manual | Deployer |
 | API tokens / OIDC secrets | Kubernetes Secret / ExternalSecret | Manual or ESO | Identity provider |
 | S3 / cloud credentials | Kubernetes Secret / IRSA | Cloud IAM rotation | Cloud provider |

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -19,6 +19,7 @@ declare -A TOOLS=(
   [kubectl]="Install kubectl: https://kubernetes.io/docs/tasks/tools/"
   [helm]="Install Helm 3: https://helm.sh/docs/intro/install/"
   [cargo]="Install Rust via rustup: https://rustup.rs/"
+  [gh]="Install GitHub CLI: https://cli.github.com/"
 )
 
 # Labels that must exist in the GitHub repo before issue automation runs.

--- a/scripts/repo-health.sh
+++ b/scripts/repo-health.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# shellcheck source=scripts/lib/errors.sh
+source "${SCRIPT_DIR}/lib/errors.sh"
 cd "${REPO_ROOT}"
 
 K8S_OPENAPI_ENABLED_VERSION="${K8S_OPENAPI_ENABLED_VERSION:-1.30}"
@@ -25,8 +27,6 @@ export K8S_OPENAPI_ENABLED_VERSION
 
 readonly TOTAL_STEPS=5
 STEP=0
-FAILED_STEP=""
-FAILED_HINT=""
 
 print_header() {
   echo ""
@@ -38,9 +38,9 @@ print_header() {
 
 begin_step() {
   STEP=$((STEP + 1))
-  local title="$1"
+  SK8S_STEP="$1"
   echo ""
-  echo "[${STEP}/${TOTAL_STEPS}] ${title}"
+  echo "[${STEP}/${TOTAL_STEPS}] ${SK8S_STEP}"
   echo "────────────────────────────────────────────────────────────"
 }
 
@@ -51,17 +51,7 @@ pass_step() {
 fail_step() {
   local name="$1"
   local hint="$2"
-  FAILED_STEP="$name"
-  FAILED_HINT="$hint"
-  echo ""
-  echo "  ✗ FAILED: ${name}"
-  echo "    Hint: ${hint}"
-  echo ""
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "  Health check stopped at step ${STEP}/${TOTAL_STEPS}: ${name}"
-  echo "  Fix the issue above, then re-run: make health"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  exit 1
+  sk8s_fail "failed at step ${STEP}/${TOTAL_STEPS}: ${name}" "${hint} — re-run: make health"
 }
 
 run_or_fail() {

--- a/scripts/tests/preflight.bats
+++ b/scripts/tests/preflight.bats
@@ -17,7 +17,8 @@ PREFLIGHT="${BATS_TEST_DIRNAME}/../preflight.sh"
   kubectl() { echo "Client Version: v1.30.0"; }
   helm()    { echo "version.BuildInfo{Version:\"v3.14.0\"}"; }
   cargo()   { echo "cargo 1.88.0"; }
-  export -f docker kind kubectl helm cargo
+  gh()      { echo "gh version 2.50.0"; }
+  export -f docker kind kubectl helm cargo gh
 
   run bash "${PREFLIGHT}"
   [ "$status" -eq 0 ]
@@ -29,7 +30,7 @@ PREFLIGHT="${BATS_TEST_DIRNAME}/../preflight.sh"
   local empty_dir
   empty_dir=$(mktemp -d)
   # Copy stubs for every tool EXCEPT kind.
-  for tool in docker kubectl helm cargo; do
+  for tool in docker kubectl helm cargo gh; do
     printf '#!/usr/bin/env bash\necho "%s stub"\n' "$tool" > "${empty_dir}/${tool}"
     chmod +x "${empty_dir}/${tool}"
   done
@@ -88,4 +89,20 @@ PREFLIGHT="${BATS_TEST_DIRNAME}/../preflight.sh"
   [ "$status" -eq 0 ]
 
   rm -rf "${stub_dir}"
+}
+
+@test "preflight exits non-zero when gh is missing" {
+  local empty_dir
+  empty_dir=$(mktemp -d)
+  # Stub every tool EXCEPT gh.
+  for tool in docker kind kubectl helm cargo; do
+    printf '#!/usr/bin/env bash\necho "%s stub"\n' "$tool" > "${empty_dir}/${tool}"
+    chmod +x "${empty_dir}/${tool}"
+  done
+
+  run env PATH="${empty_dir}:/usr/bin:/bin" bash "${PREFLIGHT}"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"[FAIL]"* ]]
+
+  rm -rf "${empty_dir}"
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ async fn main() -> Result<(), Error> {
         Commands::BenchmarkCompare(compare_args) => {
             return stellar_k8s::benchmark_compare::run_benchmark_compare(compare_args)
                 .await
-                .map_err(|e| Error::ConfigError(e.to_string()));
+                .map_err(|e| Error::config_step("benchmark compare", e));
         }
         Commands::ExportCompliance(export_args) => {
             return run_export_compliance(export_args).await;
@@ -133,16 +133,16 @@ async fn main() -> Result<(), Error> {
         Commands::Backup { command } => match command {
             BackupCommands::Create(args) => run_backup(args)
                 .await
-                .map_err(|e| Error::ConfigError(e.to_string())),
+                .map_err(|e| Error::config_step("backup create", e)),
             BackupCommands::Restore(args) => run_restore(args)
                 .await
-                .map_err(|e| Error::ConfigError(e.to_string())),
+                .map_err(|e| Error::config_step("backup restore", e)),
             BackupCommands::List(args) => run_list(args)
                 .await
-                .map_err(|e| Error::ConfigError(e.to_string())),
+                .map_err(|e| Error::config_step("backup list", e)),
             BackupCommands::Cleanup(args) => run_cleanup(args)
                 .await
-                .map_err(|e| Error::ConfigError(e.to_string())),
+                .map_err(|e| Error::config_step("backup cleanup", e)),
         },
     };
 

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -25,7 +25,8 @@ use tracing::{error, info, warn};
 use crate::error::{Error, Result};
 
 /// Labels required by issue automation before opening new issues.
-pub const REQUIRED_GH_LABELS: &[&str] = &["ci", "security", "stellar-wave", "maintenance", "hygiene"];
+pub const REQUIRED_GH_LABELS: &[&str] =
+    &["ci", "security", "stellar-wave", "maintenance", "hygiene"];
 
 /// Tools that must be present for local development and CI to function.
 /// Each entry is `(binary, install_hint)`.
@@ -47,10 +48,7 @@ pub const REQUIRED_LOCAL_TOOLS: &[(&str, &str)] = &[
         "Install Helm 3: https://helm.sh/docs/intro/install/",
     ),
     ("cargo", "Install Rust via rustup: https://rustup.rs/"),
-    (
-        "gh",
-        "Install GitHub CLI: https://cli.github.com/",
-    ),
+    ("gh", "Install GitHub CLI: https://cli.github.com/"),
 ];
 
 const GH_PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(5);

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -25,7 +25,7 @@ use tracing::{error, info, warn};
 use crate::error::{Error, Result};
 
 /// Labels required by issue automation before opening new issues.
-pub const REQUIRED_GH_LABELS: &[&str] = &["ci", "security", "stellar-wave"];
+pub const REQUIRED_GH_LABELS: &[&str] = &["ci", "security", "stellar-wave", "maintenance", "hygiene"];
 
 /// Tools that must be present for local development and CI to function.
 /// Each entry is `(binary, install_hint)`.
@@ -47,6 +47,10 @@ pub const REQUIRED_LOCAL_TOOLS: &[(&str, &str)] = &[
         "Install Helm 3: https://helm.sh/docs/intro/install/",
     ),
     ("cargo", "Install Rust via rustup: https://rustup.rs/"),
+    (
+        "gh",
+        "Install GitHub CLI: https://cli.github.com/",
+    ),
 ];
 
 const GH_PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -555,5 +559,26 @@ mod tests {
         assert!(result.is_ok(), "cargo must be found in PATH");
         let version = result.unwrap();
         assert!(!version.is_empty(), "version string must not be empty");
+    }
+
+    #[test]
+    fn required_gh_labels_includes_maintenance_and_hygiene() {
+        assert!(
+            REQUIRED_GH_LABELS.contains(&"maintenance"),
+            "REQUIRED_GH_LABELS must include 'maintenance'"
+        );
+        assert!(
+            REQUIRED_GH_LABELS.contains(&"hygiene"),
+            "REQUIRED_GH_LABELS must include 'hygiene'"
+        );
+    }
+
+    #[test]
+    fn required_local_tools_includes_gh() {
+        let binaries: Vec<&str> = REQUIRED_LOCAL_TOOLS.iter().map(|(b, _)| *b).collect();
+        assert!(
+            binaries.contains(&"gh"),
+            "REQUIRED_LOCAL_TOOLS must include the 'gh' CLI"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **#973** — Add `webhook` values section with configurable `replicaCount`, `port`, `metricsPort`, `timeoutSeconds`, `failurePolicy`, and `resources`; parameterize `webhook.yaml` template to use those values; add `webhook` schema to `values.schema.json` with enum and range validation.
- **#974** — Create `docs/rotation-workflows.md` as a unified reference for all rotation types (database credentials, mTLS certs, webhook TLS via cert-manager, network passphrase secrets); update `docs/security/credentials-and-secrets.md` quick-reference table.
- **#975** — Source `scripts/lib/errors.sh` in `repo-health.sh` so error output uses the shared `sk8s_fail` format; use `Error::config_step()` in `main.rs` for backup and benchmark-compare commands to preserve step context in error messages.
- **#976** — Add `gh` CLI to `REQUIRED_LOCAL_TOOLS` in `src/preflight.rs` and `scripts/preflight.sh`; add `"maintenance"` and `"hygiene"` to `REQUIRED_GH_LABELS` to match the shell script; add tests for the new constants; update bats stubs.

## Test plan

- [ ] `cargo check` passes (no Rust changes touch logic paths)
- [ ] `make preflight` lists `gh` as a required tool and checks `maintenance`/`hygiene` labels
- [ ] `bats scripts/tests/preflight.bats` — new `gh` missing test passes
- [ ] `helm lint charts/stellar-operator` passes with the updated `webhook.yaml` template
- [ ] `helm template . -f values.yaml` renders webhook with correct port/timeout/failurePolicy values
- [ ] Reviewing `docs/rotation-workflows.md` for completeness

Closes #973
Closes #974
Closes #975
Closes #976

