### PR TITLE
Consolidate duplicated securityContext manifest snippets in Helm chart

### DIFF
--- a/charts/stellar-operator/templates/scp-kafka-sidecar.yaml
+++ b/charts/stellar-operator/templates/scp-kafka-sidecar.yaml
@@ -57,9 +57,7 @@ spec:
     spec:
       serviceAccountName: {{ include "stellar-operator.serviceAccountName" . }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        fsGroup: 1000
+        {{- toYaml .Values.scpAnalytics.consumer.podSecurityContext | nindent 8 }}
       containers:
         - name: topology-health-consumer
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/stellar-operator/templates/webhook.yaml
+++ b/charts/stellar-operator/templates/webhook.yaml
@@ -76,10 +76,7 @@ spec:
       serviceAccountName: stellar-webhook
       automountServiceAccountToken: false
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -98,11 +95,7 @@ spec:
               containerPort: 9090
               protocol: TCP
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
             requests:
               cpu: 100m

--- a/charts/stellar-operator/tests/scp_kafka_sidecar_test.yaml
+++ b/charts/stellar-operator/tests/scp_kafka_sidecar_test.yaml
@@ -1,0 +1,33 @@
+suite: scp-kafka-sidecar
+templates:
+  - templates/scp-kafka-sidecar.yaml
+
+tests:
+  - it: renders nothing when scpAnalytics is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: topology health consumer uses the default pod security context
+    set:
+      scpAnalytics.enabled: true
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+
+  - it: topology health consumer pod security context follows overrides
+    set:
+      scpAnalytics.enabled: true
+      scpAnalytics.consumer.podSecurityContext.runAsUser: 2000
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 2000

--- a/charts/stellar-operator/tests/webhook_test.yaml
+++ b/charts/stellar-operator/tests/webhook_test.yaml
@@ -86,3 +86,27 @@ tests:
       - equal:
           path: spec.minAvailable
           value: 1
+
+  - it: webhook pod security context follows global podSecurityContext overrides
+    documentIndex: 4
+    set:
+      podSecurityContext.runAsUser: 70000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 70000
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: webhook container security context follows global securityContext overrides
+    documentIndex: 4
+    set:
+      securityContext.readOnlyRootFilesystem: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false

--- a/charts/stellar-operator/values.yaml
+++ b/charts/stellar-operator/values.yaml
@@ -575,6 +575,12 @@ scpAnalytics:
     # Log level
     logLevel: "info"
 
+    # Pod-level security context for the consumer Deployment
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      fsGroup: 1000
+
     # Resource limits
     resources:
       limits:


### PR DESCRIPTION
Closes #967

## Summary
`webhook.yaml` and `scp-kafka-sidecar.yaml` each hardcoded their own literal copy of the pod- and container-level `securityContext` blocks, instead of templating from `.Values.podSecurityContext` / `.Values.securityContext` like every other template in the chart (`deployment.yaml`, `byzantine-watcher.yaml`, `fork-detector.yaml`, `otel-collector.yaml`). Practical effect: overriding the global security context at install time silently had no effect on the webhook or SCP topology-health-consumer pods — a real (if minor) latent bug, not just a style nit.

- `webhook.yaml`: both `securityContext` blocks now use `{{- toYaml .Values.podSecurityContext | nindent 8 }}` / `.Values.securityContext`, keeping its extra `seccompProfile` field appended. Default rendered output is byte-identical to before.
- `scp-kafka-sidecar.yaml`: its pod security context intentionally differs (UID 1000 vs. the chart default 65532), so it's now parameterized via a new `scpAnalytics.consumer.podSecurityContext` value, defaulting to the previous hardcoded values — default rendered output is unchanged, but it's now overridable like everything else.
- Added `charts/stellar-operator/tests/scp_kafka_sidecar_test.yaml` and extended `tests/webhook_test.yaml` with cases that set a values override and assert the rendered pod/container actually pick it up (proving the fix, not just default-render parity).

## Test plan
- [x] helm-unittest cases added for both templates' override behavior
- [ ] CI: `helm lint --strict` + `helm template` (`helm-lint` job)
- [ ] CI: `helm unittest charts/stellar-operator --strict` (`helm-test` job)