### PR TITLE
Feat/implement release artifact provenance checks in ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,10 @@ jobs:
               echo "Tagged: $tag"
             done <<< "${{ steps.meta.outputs.tags }}"
             echo "retagged=true" >> "$GITHUB_OUTPUT"
+            FIRST_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -1)
+            DIGEST=$(docker buildx imagetools inspect "$FIRST_TAG" \
+              --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"' || echo "")
+            echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           else
             echo "⚠️ sha image not found — will build fresh"
             echo "retagged=false" >> "$GITHUB_OUTPUT"
@@ -349,3 +353,57 @@ jobs:
           prerelease: ${{ needs.validate.outputs.is_prerelease == 'true' }}
           files: release-assets/*
           fail_on_unmatched_files: false
+
+  # ── Provenance verification ────────────────────────────────────────────────
+  provenance-check:
+    name: Provenance Check
+    runs-on: ubuntu-latest
+    needs: [validate, build-artifacts, container, release]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Docker & Login
+        id: setup-docker
+        uses: ./.github/actions/setup-docker
+        with:
+          registry: ${{ env.REGISTRY }}
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts/
+
+      - name: Verify binary artifact provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          verified=0
+          failed=0
+          for tarball in artifacts/**/*.tar.gz; do
+            [[ -f "$tarball" ]] || continue
+            echo "Verifying provenance for $tarball ..."
+            if gh attestation verify "$tarball" --repo "${{ github.repository }}"; then
+              echo "  ✅ $tarball"
+              verified=$((verified + 1))
+            else
+              echo "  ❌ $tarball — attestation not found or invalid"
+              failed=$((failed + 1))
+            fi
+          done
+          echo "Verified $verified artifact(s); failed $failed"
+          [[ "$verified" -gt 0 ]] || { echo "::error::No release artifacts verified"; exit 1; }
+          [[ "$failed" -eq 0 ]] || { echo "::error::$failed artifact(s) failed provenance check"; exit 1; }
+
+      - name: Verify container image provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ steps.setup-docker.outputs.image-name }}:${{ needs.validate.outputs.version }}"
+          echo "Verifying provenance for $IMAGE ..."
+          gh attestation verify "oci://$IMAGE" --repo "${{ github.repository }}"
+          echo "✅ Container provenance verified"

--- a/src/controller/benchmark/harness.rs
+++ b/src/controller/benchmark/harness.rs
@@ -1,0 +1,254 @@
+//! Reusable benchmark harness for operator reconciliation latency.
+//!
+//! Provides a generic harness that times repeated executions of a reconcile
+//! closure and computes latency statistics (min, max, mean, p50, p95, p99).
+//! The harness is intentionally side-effect free with respect to Kubernetes:
+//! it accepts any async closure, making it usable in unit tests without a live
+//! cluster.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use stellar_k8s::controller::benchmark::harness::{HarnessConfig, ReconcileHarness};
+//!
+//! # tokio_test::block_on(async {
+//! let harness = ReconcileHarness::new(HarnessConfig {
+//!     iterations: 100,
+//!     warmup_rounds: 5,
+//! });
+//!
+//! let report = harness.run(|| async {
+//!     // simulate one reconcile cycle
+//!     tokio::time::sleep(std::time::Duration::from_micros(500)).await;
+//! }).await;
+//!
+//! println!("p99 latency: {:.2} ms", report.p99_ms);
+//! # });
+//! ```
+
+use std::future::Future;
+use std::time::{Duration, Instant};
+
+/// Configuration for [`ReconcileHarness`].
+#[derive(Debug, Clone)]
+pub struct HarnessConfig {
+    /// Number of timed iterations to run after the warmup phase.
+    pub iterations: usize,
+    /// Number of untimed warmup calls before measurement begins.
+    ///
+    /// Warmup amortises JIT compilation, cache population, and other
+    /// first-call overheads so they do not skew the reported statistics.
+    pub warmup_rounds: usize,
+}
+
+impl Default for HarnessConfig {
+    fn default() -> Self {
+        Self {
+            iterations: 100,
+            warmup_rounds: 5,
+        }
+    }
+}
+
+/// Latency statistics produced by [`ReconcileHarness::run`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct LatencyReport {
+    /// Number of timed iterations included in the report.
+    pub sample_count: usize,
+    /// Minimum observed latency in milliseconds.
+    pub min_ms: f64,
+    /// Maximum observed latency in milliseconds.
+    pub max_ms: f64,
+    /// Arithmetic mean latency in milliseconds.
+    pub mean_ms: f64,
+    /// 50th percentile (median) latency in milliseconds.
+    pub p50_ms: f64,
+    /// 95th percentile latency in milliseconds.
+    pub p95_ms: f64,
+    /// 99th percentile latency in milliseconds.
+    pub p99_ms: f64,
+}
+
+impl LatencyReport {
+    /// Compute a report from a (mutable) collection of raw duration samples.
+    ///
+    /// The samples are sorted in place for percentile computation.
+    pub fn compute(mut samples: Vec<Duration>) -> Self {
+        let n = samples.len();
+        if n == 0 {
+            return Self {
+                sample_count: 0,
+                min_ms: 0.0,
+                max_ms: 0.0,
+                mean_ms: 0.0,
+                p50_ms: 0.0,
+                p95_ms: 0.0,
+                p99_ms: 0.0,
+            };
+        }
+
+        samples.sort_unstable();
+
+        let to_ms = |d: &Duration| d.as_secs_f64() * 1_000.0;
+        let total_ms: f64 = samples.iter().map(to_ms).sum();
+
+        let percentile = |p: f64| -> f64 {
+            let idx = ((n as f64 * p / 100.0).ceil() as usize)
+                .saturating_sub(1)
+                .min(n - 1);
+            to_ms(&samples[idx])
+        };
+
+        Self {
+            sample_count: n,
+            min_ms: to_ms(&samples[0]),
+            max_ms: to_ms(&samples[n - 1]),
+            mean_ms: total_ms / n as f64,
+            p50_ms: percentile(50.0),
+            p95_ms: percentile(95.0),
+            p99_ms: percentile(99.0),
+        }
+    }
+}
+
+/// Reusable harness for measuring operator reconciliation latency.
+///
+/// Accepts any async closure that represents a single reconcile cycle and
+/// returns a [`LatencyReport`] summarising the observed wall-clock latency
+/// distribution.
+pub struct ReconcileHarness {
+    config: HarnessConfig,
+}
+
+impl ReconcileHarness {
+    /// Create a new harness with the given configuration.
+    pub fn new(config: HarnessConfig) -> Self {
+        Self { config }
+    }
+
+    /// Run the benchmark.
+    ///
+    /// The closure `f` is called `config.warmup_rounds` times (untimed) and
+    /// then `config.iterations` times (timed). Returns a [`LatencyReport`]
+    /// computed from the timed samples.
+    pub async fn run<F, Fut>(&self, mut f: F) -> LatencyReport
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = ()>,
+    {
+        for _ in 0..self.config.warmup_rounds {
+            f().await;
+        }
+
+        let mut samples = Vec::with_capacity(self.config.iterations);
+        for _ in 0..self.config.iterations {
+            let start = Instant::now();
+            f().await;
+            samples.push(start.elapsed());
+        }
+
+        LatencyReport::compute(samples)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn harness_invokes_closure_correct_number_of_times() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = counter.clone();
+
+        let harness = ReconcileHarness::new(HarnessConfig {
+            iterations: 10,
+            warmup_rounds: 3,
+        });
+
+        harness
+            .run(|| {
+                let c = counter_clone.clone();
+                async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                }
+            })
+            .await;
+
+        assert_eq!(counter.load(Ordering::SeqCst), 13, "warmup + iterations");
+    }
+
+    #[tokio::test]
+    async fn report_has_correct_sample_count() {
+        let harness = ReconcileHarness::new(HarnessConfig {
+            iterations: 20,
+            warmup_rounds: 0,
+        });
+
+        let report = harness.run(|| async {}).await;
+        assert_eq!(report.sample_count, 20);
+    }
+
+    #[tokio::test]
+    async fn percentiles_are_ordered() {
+        let harness = ReconcileHarness::new(HarnessConfig {
+            iterations: 50,
+            warmup_rounds: 0,
+        });
+
+        let report = harness
+            .run(|| async {
+                tokio::time::sleep(Duration::from_micros(10)).await;
+            })
+            .await;
+
+        assert!(report.min_ms <= report.p50_ms, "min <= p50");
+        assert!(report.p50_ms <= report.p95_ms, "p50 <= p95");
+        assert!(report.p95_ms <= report.p99_ms, "p95 <= p99");
+        assert!(report.p99_ms <= report.max_ms, "p99 <= max");
+    }
+
+    #[test]
+    fn compute_empty_samples_returns_zero_report() {
+        let report = LatencyReport::compute(vec![]);
+        assert_eq!(report.sample_count, 0);
+        assert_eq!(report.min_ms, 0.0);
+        assert_eq!(report.p99_ms, 0.0);
+    }
+
+    #[test]
+    fn compute_single_sample() {
+        let samples = vec![Duration::from_millis(42)];
+        let report = LatencyReport::compute(samples);
+        assert_eq!(report.sample_count, 1);
+        assert!((report.min_ms - 42.0).abs() < 1e-6);
+        assert!((report.max_ms - 42.0).abs() < 1e-6);
+        assert!((report.p50_ms - 42.0).abs() < 1e-6);
+        assert!((report.p99_ms - 42.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn compute_known_distribution() {
+        // 10 samples: 10ms, 20ms, ..., 100ms
+        let samples: Vec<Duration> = (1..=10).map(|i| Duration::from_millis(i * 10)).collect();
+        let report = LatencyReport::compute(samples);
+        assert_eq!(report.sample_count, 10);
+        assert!((report.min_ms - 10.0).abs() < 1e-6);
+        assert!((report.max_ms - 100.0).abs() < 1e-6);
+        // p50 = ceil(10 * 0.5) = 5th element (50ms)
+        assert!((report.p50_ms - 50.0).abs() < 1e-6);
+        // p95 = ceil(10 * 0.95) = 10th element (100ms)
+        assert!((report.p95_ms - 100.0).abs() < 1e-6);
+        // mean = 550 / 10 = 55ms
+        assert!((report.mean_ms - 55.0).abs() < 1e-6);
+    }
+
+    #[tokio::test]
+    async fn default_config_runs_without_error() {
+        let harness = ReconcileHarness::new(HarnessConfig::default());
+        let report = harness.run(|| async {}).await;
+        assert_eq!(report.sample_count, 100);
+        assert!(report.min_ms >= 0.0);
+    }
+}

--- a/src/controller/benchmark/mod.rs
+++ b/src/controller/benchmark/mod.rs
@@ -7,6 +7,7 @@
 //! 4. Writing results to a `BenchmarkReport` CR or a `ConfigMap`.
 
 pub mod collector;
+pub mod harness;
 pub mod pod_builder;
 pub mod reconciler;
 

--- a/src/controller/feature_flags.rs
+++ b/src/controller/feature_flags.rs
@@ -46,6 +46,69 @@ use tracing::{info, warn};
 /// Name of the feature-flags ConfigMap the operator watches.
 pub const FEATURE_FLAGS_CONFIGMAP: &str = "stellar-operator-config";
 
+/// All recognised feature-flag keys.
+///
+/// Any key present in the ConfigMap that is *not* listed here is treated as
+/// unknown and surfaced as a [`FlagValidationWarning::UnknownKey`].
+pub const KNOWN_FLAGS: &[&str] = &[
+    "enable_cve_scanning",
+    "enable_read_pool",
+    "enable_dr",
+    "enable_peer_discovery",
+    "enable_archive_health",
+    "enable_soroban_metrics",
+];
+
+/// A warning produced by [`validate_config_map_data`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FlagValidationWarning {
+    /// The ConfigMap contains a key that is not in [`KNOWN_FLAGS`].
+    UnknownKey(String),
+    /// A recognised key has a value that is not a recognised boolean string.
+    InvalidValue { key: String, value: String },
+}
+
+impl std::fmt::Display for FlagValidationWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownKey(key) => {
+                write!(f, "unknown feature flag '{key}' — will be ignored")
+            }
+            Self::InvalidValue { key, value } => {
+                write!(
+                    f,
+                    "invalid value '{value}' for flag '{key}' — expected true/false/1/0/yes/no; reverting to default"
+                )
+            }
+        }
+    }
+}
+
+/// Validate `data` from a feature-flags ConfigMap against the registry.
+///
+/// Returns a (possibly empty) list of warnings for unknown keys and
+/// unrecognised boolean values. The warnings are purely advisory: callers
+/// can choose to log them and proceed, or surface them as status conditions.
+/// This function never mutates or rejects entries — that is left to
+/// [`FeatureFlags::from_config_map_data`].
+pub fn validate_config_map_data(data: &BTreeMap<String, String>) -> Vec<FlagValidationWarning> {
+    let valid_bool_values = ["true", "false", "1", "0", "yes", "no"];
+    let mut warnings = Vec::new();
+
+    for (key, value) in data {
+        if !KNOWN_FLAGS.contains(&key.as_str()) {
+            warnings.push(FlagValidationWarning::UnknownKey(key.clone()));
+        } else if !valid_bool_values.contains(&value.to_lowercase().as_str()) {
+            warnings.push(FlagValidationWarning::InvalidValue {
+                key: key.clone(),
+                value: value.clone(),
+            });
+        }
+    }
+
+    warnings
+}
+
 /// Runtime feature flags. All fields default to safe production values.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FeatureFlags {
@@ -134,6 +197,15 @@ pub async fn watch_feature_flags(
         match event {
             Ok(Event::Apply(cm)) | Ok(Event::InitApply(cm)) => {
                 let data = cm.data.clone().unwrap_or_default();
+
+                for warning in validate_config_map_data(&data) {
+                    warn!(
+                        configmap = FEATURE_FLAGS_CONFIGMAP,
+                        warning = %warning,
+                        "Feature-flag ConfigMap validation warning"
+                    );
+                }
+
                 let new_flags = FeatureFlags::from_config_map_data(&data);
 
                 let mut current = flags.write().await;
@@ -346,5 +418,94 @@ mod tests {
         }
         let flags = shared.read().await;
         assert!(flags.enable_dr);
+    }
+
+    // ── Registry and validation tests ─────────────────────────────────────────
+
+    #[test]
+    fn known_flags_covers_all_struct_fields() {
+        // Every field on FeatureFlags must appear in KNOWN_FLAGS.
+        let all_keys: Vec<&str> = vec![
+            "enable_cve_scanning",
+            "enable_read_pool",
+            "enable_dr",
+            "enable_peer_discovery",
+            "enable_archive_health",
+            "enable_soroban_metrics",
+        ];
+        for key in &all_keys {
+            assert!(
+                KNOWN_FLAGS.contains(key),
+                "'{key}' is missing from KNOWN_FLAGS"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_returns_no_warnings_for_known_keys() {
+        let d = data(&[
+            ("enable_cve_scanning", "true"),
+            ("enable_read_pool", "false"),
+            ("enable_dr", "yes"),
+            ("enable_peer_discovery", "1"),
+            ("enable_archive_health", "0"),
+            ("enable_soroban_metrics", "no"),
+        ]);
+        let warnings = validate_config_map_data(&d);
+        assert!(warnings.is_empty(), "expected no warnings, got: {warnings:?}");
+    }
+
+    #[test]
+    fn validate_warns_on_unknown_key() {
+        let d = data(&[("enable_dr", "true"), ("unknown_feature", "true")]);
+        let warnings = validate_config_map_data(&d);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0],
+            FlagValidationWarning::UnknownKey("unknown_feature".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_warns_on_multiple_unknown_keys() {
+        let d = data(&[
+            ("enable_dr", "true"),
+            ("foo_flag", "true"),
+            ("bar_flag", "false"),
+        ]);
+        let mut warnings = validate_config_map_data(&d);
+        warnings.sort_by_key(|w| format!("{w:?}"));
+        assert_eq!(warnings.len(), 2);
+    }
+
+    #[test]
+    fn validate_warns_on_invalid_bool_value() {
+        let d = data(&[("enable_dr", "enabled")]);
+        let warnings = validate_config_map_data(&d);
+        assert_eq!(warnings.len(), 1);
+        assert!(matches!(
+            &warnings[0],
+            FlagValidationWarning::InvalidValue { key, .. } if key == "enable_dr"
+        ));
+    }
+
+    #[test]
+    fn validate_empty_data_returns_no_warnings() {
+        let warnings = validate_config_map_data(&BTreeMap::new());
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn flag_validation_warning_display_includes_key_name() {
+        let w = FlagValidationWarning::UnknownKey("mystery_flag".to_string());
+        assert!(w.to_string().contains("mystery_flag"));
+
+        let w2 = FlagValidationWarning::InvalidValue {
+            key: "enable_dr".to_string(),
+            value: "enabled".to_string(),
+        };
+        let s = w2.to_string();
+        assert!(s.contains("enable_dr"));
+        assert!(s.contains("enabled"));
     }
 }

--- a/src/webhook/server.rs
+++ b/src/webhook/server.rs
@@ -1437,4 +1437,229 @@ mod tests {
         assert!(!sanitized.contains("super-secret"));
         assert!(!sanitized.contains("secret-value"));
     }
+
+    // ── Stress tests: throughput and timeout behaviour ────────────────────────
+
+    fn valid_stellarnode_object() -> serde_json::Value {
+        serde_json::json!({
+            "metadata": {
+                "name": "stress-validator",
+                "namespace": "default",
+                "labels": {"project-id": "stress", "owner": "stress-test"}
+            },
+            "spec": {
+                "nodeType": "Validator",
+                "network": "testnet",
+                "version": "v21.0.0",
+                "replicas": 1,
+                "validatorConfig": {
+                    "seedSecretRef": "seed",
+                    "enableHistoryArchive": false,
+                    "historyArchiveUrls": []
+                }
+            }
+        })
+    }
+
+    fn invalid_stellarnode_object() -> serde_json::Value {
+        serde_json::json!({
+            "metadata": {"name": "bad", "namespace": "default"},
+            "spec": {"nodeType": "InvalidKind", "network": "testnet", "version": "v21.0.0"}
+        })
+    }
+
+    /// Concurrent valid requests all complete successfully and return `allowed`.
+    #[tokio::test]
+    async fn stress_concurrent_valid_requests_all_allowed() {
+        let server = std::sync::Arc::new(WebhookServer::new(WasmRuntime::new().unwrap()));
+        let obj = valid_stellarnode_object();
+        const CONCURRENCY: usize = 50;
+
+        let futures: Vec<_> = (0..CONCURRENCY)
+            .map(|_| {
+                let s = server.clone();
+                let o = obj.clone();
+                async move { s.validate(validation_input(Operation::Create, Some(o))).await }
+            })
+            .collect();
+
+        let results = futures::future::join_all(futures).await;
+
+        let denied: Vec<_> = results.iter().filter(|r| !r.allowed).collect();
+        assert!(
+            denied.is_empty(),
+            "{} of {} concurrent requests were unexpectedly denied",
+            denied.len(),
+            CONCURRENCY
+        );
+    }
+
+    /// Concurrent invalid requests are all denied; none cause a panic or hang.
+    #[tokio::test]
+    async fn stress_concurrent_invalid_requests_all_denied() {
+        let server = std::sync::Arc::new(WebhookServer::new(WasmRuntime::new().unwrap()));
+        let obj = invalid_stellarnode_object();
+        const CONCURRENCY: usize = 30;
+
+        let futures: Vec<_> = (0..CONCURRENCY)
+            .map(|_| {
+                let s = server.clone();
+                let o = obj.clone();
+                async move { s.validate(validation_input(Operation::Create, Some(o))).await }
+            })
+            .collect();
+
+        let results = futures::future::join_all(futures).await;
+
+        let allowed: Vec<_> = results.iter().filter(|r| r.allowed).collect();
+        assert!(
+            allowed.is_empty(),
+            "{} of {} invalid requests were unexpectedly allowed",
+            allowed.len(),
+            CONCURRENCY
+        );
+        // Every denied result must carry an error message.
+        for r in &results {
+            assert!(
+                r.message.is_some(),
+                "denied result is missing an error message"
+            );
+        }
+    }
+
+    /// Mixed concurrent load: valid and invalid requests are segregated correctly.
+    #[tokio::test]
+    async fn stress_mixed_concurrent_requests_segregated_correctly() {
+        let server = std::sync::Arc::new(WebhookServer::new(WasmRuntime::new().unwrap()));
+        let valid = valid_stellarnode_object();
+        let invalid = invalid_stellarnode_object();
+        const HALF: usize = 20;
+
+        let valid_futures: Vec<_> = (0..HALF)
+            .map(|_| {
+                let s = server.clone();
+                let o = valid.clone();
+                async move {
+                    let r = s.validate(validation_input(Operation::Create, Some(o))).await;
+                    ("valid", r.allowed)
+                }
+            })
+            .collect();
+
+        let invalid_futures: Vec<_> = (0..HALF)
+            .map(|_| {
+                let s = server.clone();
+                let o = invalid.clone();
+                async move {
+                    let r = s.validate(validation_input(Operation::Create, Some(o))).await;
+                    ("invalid", r.allowed)
+                }
+            })
+            .collect();
+
+        let all_futures: Vec<_> = valid_futures
+            .into_iter()
+            .chain(invalid_futures)
+            .collect();
+
+        let results = futures::future::join_all(all_futures).await;
+
+        let (valid_results, invalid_results): (Vec<_>, Vec<_>) =
+            results.iter().partition(|(tag, _)| *tag == "valid");
+
+        let valid_denied = valid_results.iter().filter(|(_, ok)| !ok).count();
+        let invalid_allowed = invalid_results.iter().filter(|(_, ok)| *ok).count();
+
+        assert_eq!(
+            valid_denied, 0,
+            "{valid_denied} valid requests were incorrectly denied"
+        );
+        assert_eq!(
+            invalid_allowed, 0,
+            "{invalid_allowed} invalid requests were incorrectly allowed"
+        );
+    }
+
+    /// High sequential throughput: server handles 200 sequential validates
+    /// without degradation (each must return a result, never hang).
+    #[tokio::test]
+    async fn stress_high_sequential_throughput_no_hang() {
+        let server = WebhookServer::new(WasmRuntime::new().unwrap());
+        let obj = valid_stellarnode_object();
+        const TOTAL: usize = 200;
+
+        for _ in 0..TOTAL {
+            let input = validation_input(Operation::Create, Some(obj.clone()));
+            let result = server.validate(input).await;
+            assert!(
+                result.allowed,
+                "sequential request was unexpectedly denied: {:?}",
+                result.message
+            );
+        }
+    }
+
+    /// Timeout resilience: a fail-open plugin that traps must not block other
+    /// concurrent requests — all complete within a reasonable wall-clock window.
+    #[tokio::test]
+    async fn stress_trap_plugin_does_not_block_concurrent_requests() {
+        let runtime = WasmRuntime::new().unwrap();
+        let server = std::sync::Arc::new(WebhookServer::new(runtime));
+
+        // Load a fail-open plugin that traps immediately.
+        let wasm = wat::parse_str(
+            r#"(module
+                  (func (export "validate") unreachable)
+                  (memory (export "memory") 1)
+               )"#,
+        )
+        .unwrap();
+        let config = PluginConfig {
+            metadata: PluginMetadata {
+                name: "stress-trap".to_string(),
+                version: "0.0.1".to_string(),
+                description: None,
+                author: None,
+                sha256: None,
+                limits: PluginLimits::default(),
+            },
+            wasm_binary: Some(base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                &wasm,
+            )),
+            config_map_ref: None,
+            secret_ref: None,
+            url: None,
+            operations: vec![Operation::Create],
+            enabled: true,
+            fail_open: true,
+            plugin_config: BTreeMap::new(),
+        };
+        server.add_plugin(config).await.unwrap();
+
+        let obj = valid_stellarnode_object();
+        const CONCURRENCY: usize = 20;
+
+        let futures: Vec<_> = (0..CONCURRENCY)
+            .map(|_| {
+                let s = server.clone();
+                let o = obj.clone();
+                async move { s.validate(validation_input(Operation::Create, Some(o))).await }
+            })
+            .collect();
+
+        // All requests complete (fail-open means allowed despite the trap).
+        let results = futures::future::join_all(futures).await;
+        for r in &results {
+            assert!(
+                r.allowed,
+                "fail-open trap plugin should allow: {:?}",
+                r.message
+            );
+            assert!(
+                !r.warnings.is_empty(),
+                "fail-open trap plugin should emit a warning"
+            );
+        }
+    }
 }


### PR DESCRIPTION
feat: release provenance checks, benchmark harness, webhook stress tests, feature-flag registry

  Closes #1054
  Closes #1055
  Closes #1056
  Closes #1057

  Body:

  ## Summary

  - **#1054 — Release artifact provenance checks in CI**: Adds a `provenance-check` job to `.github/workflows/release.yml` that runs after the GitHub Release is published. It downloads every binary `.tar.gz` artifact and
  the container image, then verifies each has a valid SLSA provenance attestation using `gh attestation verify`. Also fixes the container retag path so the manifest digest is captured and available for the
  `actions/attest-build-provenance` step.

  - **#1055 — Reusable benchmark harness for operator reconciliation latency**: Adds `src/controller/benchmark/harness.rs` with a `ReconcileHarness` struct and a `LatencyReport` type. The harness accepts any async closure
  representing a reconcile cycle, runs configurable warmup rounds and timed iterations, and returns min/max/mean/p50/p95/p99 latency statistics. Pure Rust, no Kubernetes dependency — usable directly in unit tests. Includes
  eight unit tests covering edge cases (empty samples, single sample, known distribution, ordering invariants).

  - **#1056 — Webhook stress tests for throughput and timeout behaviour**: Extends the existing `#[cfg(test)] mod tests` block in `src/webhook/server.rs` with five stress tests: concurrent valid requests all allowed,
  concurrent invalid requests all denied (with error messages), mixed concurrent load correctly segregated, high sequential throughput (200 requests) without hanging, and a concurrent fail-open trap-plugin test verifying
  the server doesn't block under plugin failures.

  - **#1057 — Centralized feature-flag registry and validation**: Adds `KNOWN_FLAGS: &[&str]`, a `FlagValidationWarning` enum (`UnknownKey`, `InvalidValue`), and a `validate_config_map_data()` function to
  `src/controller/feature_flags.rs`. The watcher now calls this function on every ConfigMap change and logs any warnings. Adds seven unit tests covering full coverage of the new registry surface.

  ## Test plan

  - [ ] `cargo test --locked feature_flags` — all new registry and validation tests pass
  - [ ] `cargo test --locked benchmark::harness` — all harness tests pass
  - [ ] `cargo test --locked webhook::server` — all new stress tests pass (may be slow; uses `tokio::time::sleep` in throughput test)
  - [ ] Review `.github/workflows/release.yml` — confirm `provenance-check` job is correctly gated on `release` completion and that `steps.retag.outputs.digest` is now populated in the retag path