### PR TITLE
feat(metrics): expose Horizon request error ratio and DB query duration

### DIFF
--- a/monitoring/grafana-horizon-dashboard.json
+++ b/monitoring/grafana-horizon-dashboard.json
@@ -1,5 +1,20 @@
 {
-  "annotations": {"list": [{"builtIn": 1, "datasource": {"type": "grafana", "uid": "-- Grafana --"}, "enable": true, "hide": true, "iconColor": "rgba(0, 211, 255, 1)", "name": "Annotations & Alerts", "type": "dashboard"}]},
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -7,20 +22,804 @@
   "links": [],
   "liveNow": true,
   "panels": [
-    {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "description": "Horizon API request rate", "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "Requests/sec", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}, "unit": "reqps"}}, "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0}, "id": 1, "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}, "targets": [{"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "rate(stellar_horizon_requests_total{node_name=~\"$node\"}[5m])", "legendFormat": "{{node_name}}", "refId": "A"}], "title": "Horizon API Request Rate", "type": "timeseries"},
-    {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "description": "Horizon API request latency percentiles", "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "Latency", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.5}, {"color": "red", "value": 1}]}, "unit": "s"}}, "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0}, "id": 2, "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}, "targets": [{"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "histogram_quantile(0.50, rate(stellar_horizon_request_duration_seconds_bucket{node_name=~\"$node\"}[5m]))", "legendFormat": "p50 - {{node_name}}", "refId": "A"}, {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "histogram_quantile(0.95, rate(stellar_horizon_request_duration_seconds_bucket{node_name=~\"$node\"}[5m]))", "legendFormat": "p95 - {{node_name}}", "refId": "B"}, {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "histogram_quantile(0.99, rate(stellar_horizon_request_duration_seconds_bucket{node_name=~\"$node\"}[5m]))", "legendFormat": "p99 - {{node_name}}", "refId": "C"}], "title": "Horizon API Latency (Percentiles)", "type": "timeseries"},
-    {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "description": "Horizon ingestion lag behind the network", "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 30}, {"color": "red", "value": 60}]}, "unit": "s"}}, "gridPos": {"h": 4, "w": 6, "x": 0, "y": 8}, "id": 3, "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}, "pluginVersion": "10.0.0", "targets": [{"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "stellar_horizon_ingestion_lag_seconds{node_name=~\"$node\"}", "legendFormat": "{{node_name}}", "refId": "A"}], "title": "Ingestion Lag", "type": "stat"},
-    {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "description": "Database replication lag", "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 5}, {"color": "red", "value": 10}]}, "unit": "s"}}, "gridPos": {"h": 4, "w": 6, "x": 6, "y": 8}, "id": 4, "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"}, "pluginVersion": "10.0.0", "targets": [{"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "stellar_horizon_db_replication_lag_seconds{node_name=~\"$node\"}", "legendFormat": "{{node_name}}", "refId": "A"}], "title": "DB Replication Lag", "type": "stat"},
-    {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "description": "Database connection pool status", "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "Connections", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "normal"}, "thresholdsStyle": {"mode": "off"}}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}, "unit": "short"}}, "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8}, "id": 5, "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}, "targets": [{"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "stellar_database_connection_pool_active{node_name=~\"$node\",node_type=\"horizon\"}", "legendFormat": "Active - {{node_name}}", "refId": "A"}, {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "stellar_database_connection_pool_idle{node_name=~\"$node\",node_type=\"horizon\"}", "legendFormat": "Idle - {{node_name}}", "refId": "B"}], "title": "Database Connection Pool", "type": "timeseries"},
-    {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "description": "Transaction throughput processed by Horizon", "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "TPS", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "opacity", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}, "unit": "tps"}}, "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16}, "id": 6, "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}, "targets": [{"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "stellar_transaction_throughput_tps{node_type=\"horizon\",node_name=~\"$node\"}", "legendFormat": "{{node_name}}", "refId": "A"}], "title": "Transaction Throughput (TPS)", "type": "timeseries"},
-    {"datasource": {"type": "prometheus", "uid": "${datasource}"}, "description": "Database size and growth", "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}, "unit": "decgbytes"}}, "gridPos": {"h": 8, "w": 12, "x": 12, "y": 16}, "id": 7, "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}}, "targets": [{"datasource": {"type": "prometheus", "uid": "${datasource}"}, "expr": "stellar_database_size_bytes{node_name=~\"$node\",node_type=\"horizon\"} / 1024 / 1024 / 1024", "legendFormat": "{{node_name}}", "refId": "A"}], "title": "Database Size (GB)", "type": "timeseries"}
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Horizon API request rate",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Requests/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(stellar_horizon_requests_total{node_name=~\"$node\"}[5m])",
+          "legendFormat": "{{node_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Horizon API Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Horizon API request latency percentiles",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Latency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, rate(stellar_horizon_request_duration_seconds_bucket{node_name=~\"$node\"}[5m]))",
+          "legendFormat": "p50 - {{node_name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, rate(stellar_horizon_request_duration_seconds_bucket{node_name=~\"$node\"}[5m]))",
+          "legendFormat": "p95 - {{node_name}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, rate(stellar_horizon_request_duration_seconds_bucket{node_name=~\"$node\"}[5m]))",
+          "legendFormat": "p99 - {{node_name}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Horizon API Latency (Percentiles)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Horizon ingestion lag behind the network",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 30
+              },
+              {
+                "color": "red",
+                "value": 60
+              }
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "stellar_horizon_ingestion_lag_seconds{node_name=~\"$node\"}",
+          "legendFormat": "{{node_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Ingestion Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Database replication lag",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "stellar_horizon_db_replication_lag_seconds{node_name=~\"$node\"}",
+          "legendFormat": "{{node_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "DB Replication Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Database connection pool status",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Connections",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "stellar_database_connection_pool_active{node_name=~\"$node\",node_type=\"horizon\"}",
+          "legendFormat": "Active - {{node_name}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "stellar_database_connection_pool_idle{node_name=~\"$node\",node_type=\"horizon\"}",
+          "legendFormat": "Idle - {{node_name}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Database Connection Pool",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Transaction throughput processed by Horizon",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "TPS",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "tps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "stellar_transaction_throughput_tps{node_type=\"horizon\",node_name=~\"$node\"}",
+          "legendFormat": "{{node_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Transaction Throughput (TPS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Database size and growth",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decgbytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "stellar_database_size_bytes{node_name=~\"$node\",node_type=\"horizon\"} / 1024 / 1024 / 1024",
+          "legendFormat": "{{node_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Size (GB)",
+      "type": "timeseries"
+    },
+    {
+      "id": 8,
+      "title": "Horizon Request Error Ratio",
+      "type": "timeseries",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "single"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "stellar_horizon_request_error_ratio{node_name=~\"$node\"}",
+          "legendFormat": "{{node_name}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Horizon DB Query Duration (avg)",
+      "type": "timeseries",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "single"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${datasource}",
+          "expr": "stellar_horizon_db_query_duration_seconds{node_name=~\"$node\"}",
+          "legendFormat": "{{node_name}}",
+          "refId": "A"
+        }
+      ]
+    }
   ],
   "refresh": "10s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["stellar", "horizon", "api"],
-  "templating": {"list": [{"current": {"selected": false, "text": "Prometheus", "value": "prometheus"}, "hide": 0, "includeAll": false, "label": "Datasource", "multi": false, "name": "datasource", "options": [], "query": "prometheus", "refresh": 1, "regex": "", "skipUrlSync": false, "type": "datasource"}, {"current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "${datasource}"}, "definition": "label_values(stellar_horizon_requests_total, node_name)", "hide": 0, "includeAll": true, "label": "Horizon Node", "multi": true, "name": "node", "options": [], "query": {"query": "label_values(stellar_horizon_requests_total, node_name)", "refId": "PrometheusVariableQueryEditor-VariableQuery"}, "refresh": 1, "regex": "", "skipUrlSync": false, "sort": 1, "type": "query"}]},
-  "time": {"from": "now-1h", "to": "now"},
+  "tags": [
+    "stellar",
+    "horizon",
+    "api"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(stellar_horizon_requests_total, node_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Horizon Node",
+        "multi": true,
+        "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values(stellar_horizon_requests_total, node_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "Stellar Horizon Nodes - API Metrics",

--- a/src/controller/horizon_metrics_collector.rs
+++ b/src/controller/horizon_metrics_collector.rs
@@ -142,6 +142,22 @@ impl HorizonMetricsCollector {
                                 &ep.hardware_generation,
                                 snap.ingestion_lag,
                             );
+                            crate::controller::metrics::set_horizon_request_error_ratio(
+                                &ep.namespace,
+                                &ep.name,
+                                &ep.node_type,
+                                &ep.network,
+                                &ep.hardware_generation,
+                                snap.request_error_ratio,
+                            );
+                            crate::controller::metrics::set_horizon_db_query_duration_seconds(
+                                &ep.namespace,
+                                &ep.name,
+                                &ep.node_type,
+                                &ep.network,
+                                &ep.hardware_generation,
+                                snap.db_query_duration_seconds,
+                            );
                         }
 
                         info!(
@@ -284,10 +300,17 @@ impl HorizonMetricsCollector {
 /// Extracts:
 /// - `horizon_ingest_transactions_per_second` → `tps`
 /// - `horizon_ingest_pending_txqueue_count`   → `queue_length`
-/// - `horizon_ingest_ledger_ingestion_count`  → proxy for ingestion lag when
-///   combined with the current ledger (best-effort)
+/// - `horizon_ingest_latest_ledger_age_seconds` → `ingestion_lag`
+/// - `horizon_requests_total{status_code="4xx/5xx"}` → `request_error_ratio`
+/// - `horizon_db_query_duration_seconds_{sum,count}` → `db_query_duration_seconds`
 pub fn parse_prometheus_metrics(text: &str) -> StellarMetricsSnapshot {
     let mut values: HashMap<&str, f64> = HashMap::new();
+
+    // Accumulators for label-aware metrics.
+    let mut request_total: f64 = 0.0;
+    let mut request_error: f64 = 0.0;
+    let mut db_duration_sum: f64 = 0.0;
+    let mut db_duration_count: f64 = 0.0;
 
     for line in text.lines() {
         let line = line.trim();
@@ -295,7 +318,6 @@ pub fn parse_prometheus_metrics(text: &str) -> StellarMetricsSnapshot {
             continue;
         }
         // Lines look like: `metric_name{labels} value [timestamp]`
-        // We split on the first '{' or space.
         let (key, rest) = if let Some(pos) = line.find('{') {
             (&line[..pos], &line[pos..])
         } else if let Some(pos) = line.find(' ') {
@@ -304,17 +326,50 @@ pub fn parse_prometheus_metrics(text: &str) -> StellarMetricsSnapshot {
             continue;
         };
 
-        // The value is the first whitespace-separated token after closing '}' or after the key.
-        let value_str = if rest.contains('}') {
-            rest.split_once('}').map(|x| x.1).unwrap_or("").trim()
+        // Extract label block (between '{' and '}') and value after '}'.
+        let (labels_str, value_str) = if rest.starts_with('{') {
+            let after_open = &rest[1..];
+            if let Some(close) = after_open.find('}') {
+                let lbls = &after_open[..close];
+                let val = after_open[close + 1..].trim();
+                (lbls, val)
+            } else {
+                ("", rest.trim())
+            }
         } else {
-            rest.trim()
+            ("", rest.trim())
         };
 
-        // May have trailing timestamp.
         let value_str = value_str.split_whitespace().next().unwrap_or("");
-        if let Ok(v) = value_str.parse::<f64>() {
-            values.insert(key, v);
+        let v = match value_str.parse::<f64>() {
+            Ok(f) => f,
+            Err(_) => continue,
+        };
+
+        match key {
+            "horizon_requests_total" => {
+                request_total += v;
+                // Check if status_code label starts with '4' or '5'.
+                for part in labels_str.split(',') {
+                    let part = part.trim();
+                    if let Some(val) = part.strip_prefix("status_code=\"") {
+                        let code = val.trim_end_matches('"');
+                        if code.starts_with('4') || code.starts_with('5') {
+                            request_error += v;
+                        }
+                        break;
+                    }
+                }
+            }
+            "horizon_db_query_duration_seconds_sum" => {
+                db_duration_sum += v;
+            }
+            "horizon_db_query_duration_seconds_count" => {
+                db_duration_count += v;
+            }
+            _ => {
+                values.insert(key, v);
+            }
         }
     }
 
@@ -344,12 +399,26 @@ pub fn parse_prometheus_metrics(text: &str) -> StellarMetricsSnapshot {
         .copied()
         .unwrap_or(0.0) as i64;
 
+    let request_error_ratio = if request_total > 0.0 {
+        request_error / request_total
+    } else {
+        0.0
+    };
+
+    let db_query_duration_seconds = if db_duration_count > 0.0 {
+        db_duration_sum / db_duration_count
+    } else {
+        0.0
+    };
+
     StellarMetricsSnapshot {
         tps,
         queue_length,
         ingestion_lag,
         ledger_sequence,
         active_connections,
+        request_error_ratio,
+        db_query_duration_seconds,
         updated_at: chrono::Utc::now(),
     }
 }
@@ -378,6 +447,8 @@ fn parse_info_json(info: &serde_json::Value) -> StellarMetricsSnapshot {
         ingestion_lag,
         ledger_sequence,
         active_connections: 0,
+        request_error_ratio: 0.0,
+        db_query_duration_seconds: 0.0,
         updated_at: chrono::Utc::now(),
     }
 }
@@ -444,6 +515,45 @@ horizon_ingest_pending_txqueue_count{instance="h0"} 300
         let snap = parse_prometheus_metrics(text);
         // i64 truncation: 99.7 -> 99
         assert_eq!(snap.tps, 99);
+    }
+
+    #[test]
+    fn test_parse_prometheus_metrics_request_error_ratio() {
+        let text = r#"
+horizon_requests_total{status_code="200",route="/transactions"} 900
+horizon_requests_total{status_code="404",route="/not-found"} 80
+horizon_requests_total{status_code="500",route="/metrics"} 20
+"#;
+        let snap = parse_prometheus_metrics(text);
+        // 100 errors out of 1000 total = 0.1
+        let ratio = snap.request_error_ratio;
+        assert!((ratio - 0.1).abs() < 1e-9, "expected 0.1, got {ratio}");
+    }
+
+    #[test]
+    fn test_parse_prometheus_metrics_request_error_ratio_zero_total() {
+        let snap = parse_prometheus_metrics("");
+        assert_eq!(snap.request_error_ratio, 0.0);
+    }
+
+    #[test]
+    fn test_parse_prometheus_metrics_db_query_duration() {
+        let text = r#"
+horizon_db_query_duration_seconds_sum{db="core"} 0.5
+horizon_db_query_duration_seconds_count{db="core"} 100
+horizon_db_query_duration_seconds_sum{db="history"} 1.5
+horizon_db_query_duration_seconds_count{db="history"} 300
+"#;
+        let snap = parse_prometheus_metrics(text);
+        // sum=2.0, count=400 → avg=0.005
+        let dur = snap.db_query_duration_seconds;
+        assert!((dur - 0.005).abs() < 1e-9, "expected 0.005, got {dur}");
+    }
+
+    #[test]
+    fn test_parse_prometheus_metrics_db_query_duration_zero_count() {
+        let snap = parse_prometheus_metrics("");
+        assert_eq!(snap.db_query_duration_seconds, 0.0);
     }
 
     #[test]

--- a/src/controller/metrics.rs
+++ b/src/controller/metrics.rs
@@ -13,6 +13,8 @@
 //! - `stellar_horizon_tps` (gauge): Horizon TPS labeled by namespace/name/node_type/network/hardware_generation.
 //! - `stellar_horizon_queue_length` (gauge): pending Horizon request queue length labeled by namespace/name/node_type/network/hardware_generation.
 //! - `stellar_node_active_connections` (gauge): active peer connections labeled by namespace/name/node_type/network/hardware_generation.
+//! - `stellar_horizon_request_error_ratio` (gauge): ratio (0.0-1.0) of Horizon API requests returning 4xx/5xx, labeled by namespace/name/node_type/network/hardware_generation.
+//! - `stellar_horizon_db_query_duration_seconds` (gauge): average Horizon database query duration in seconds, labeled by namespace/name/node_type/network/hardware_generation.
 
 use std::sync::atomic::{AtomicI64, AtomicU64};
 
@@ -70,6 +72,14 @@ pub static HORIZON_QUEUE_LENGTH: Lazy<Family<NodeLabels, Gauge<i64, AtomicI64>>>
 
 /// Gauge tracking active connections per node
 pub static ACTIVE_CONNECTIONS: Lazy<Family<NodeLabels, Gauge<i64, AtomicI64>>> =
+    Lazy::new(Family::default);
+
+/// Gauge tracking the ratio (0.0-1.0) of Horizon API requests that returned a 4xx/5xx status
+pub static HORIZON_REQUEST_ERROR_RATIO: Lazy<Family<NodeLabels, Gauge<f64, AtomicU64>>> =
+    Lazy::new(Family::default);
+
+/// Gauge tracking average Horizon database query duration in seconds
+pub static HORIZON_DB_QUERY_DURATION_SECONDS: Lazy<Family<NodeLabels, Gauge<f64, AtomicU64>>> =
     Lazy::new(Family::default);
 
 /// Gauge tracking archive integrity status (1 = healthy, 0 = corrupted)
@@ -392,6 +402,16 @@ pub static REGISTRY: Lazy<Registry> = Lazy::new(|| {
         "stellar_node_active_connections",
         "Number of active peer connections",
         ACTIVE_CONNECTIONS.clone(),
+    );
+    registry.register(
+        "stellar_horizon_request_error_ratio",
+        "Ratio (0.0-1.0) of Horizon API requests that returned a 4xx/5xx status",
+        HORIZON_REQUEST_ERROR_RATIO.clone(),
+    );
+    registry.register(
+        "stellar_horizon_db_query_duration_seconds",
+        "Average Horizon database query duration in seconds",
+        HORIZON_DB_QUERY_DURATION_SECONDS.clone(),
     );
     registry.register(
         "stellar_archive_ledger_lag",
@@ -1078,6 +1098,48 @@ pub fn set_active_connections(
         hardware_generation: hardware_generation.to_string(),
     };
     ACTIVE_CONNECTIONS.get_or_create(&labels).set(connections);
+}
+
+/// Update the Horizon API request error ratio (0.0-1.0) for a node
+pub fn set_horizon_request_error_ratio(
+    namespace: &str,
+    name: &str,
+    node_type: &str,
+    network: &str,
+    hardware_generation: &str,
+    error_ratio: f64,
+) {
+    let labels = NodeLabels {
+        namespace: namespace.to_string(),
+        name: name.to_string(),
+        node_type: node_type.to_string(),
+        network: network.to_string(),
+        hardware_generation: hardware_generation.to_string(),
+    };
+    HORIZON_REQUEST_ERROR_RATIO
+        .get_or_create(&labels)
+        .set(error_ratio);
+}
+
+/// Update the average Horizon database query duration (seconds) for a node
+pub fn set_horizon_db_query_duration_seconds(
+    namespace: &str,
+    name: &str,
+    node_type: &str,
+    network: &str,
+    hardware_generation: &str,
+    duration_seconds: f64,
+) {
+    let labels = NodeLabels {
+        namespace: namespace.to_string(),
+        name: name.to_string(),
+        node_type: node_type.to_string(),
+        network: network.to_string(),
+        hardware_generation: hardware_generation.to_string(),
+    };
+    HORIZON_DB_QUERY_DURATION_SECONDS
+        .get_or_create(&labels)
+        .set(duration_seconds);
 }
 
 fn generate_laplace_noise(epsilon: f64, sensitivity: f64) -> f64 {

--- a/src/rest_api/metrics_store.rs
+++ b/src/rest_api/metrics_store.rs
@@ -27,6 +27,8 @@
 //!     ingestion_lag: 2,
 //!     ledger_sequence: 49_500_000,
 //!     active_connections: 15,
+//!     request_error_ratio: 0.02,
+//!     db_query_duration_seconds: 0.005,
 //!     updated_at: chrono::Utc::now(),
 //! });
 //!
@@ -74,6 +76,10 @@ pub struct StellarMetricsSnapshot {
     pub ledger_sequence: u64,
     /// Number of active peer connections.
     pub active_connections: i64,
+    /// Ratio (0.0–1.0) of Horizon API requests returning 4xx/5xx, derived from `/metrics`.
+    pub request_error_ratio: f64,
+    /// Average Horizon database query duration in seconds, derived from `/metrics`.
+    pub db_query_duration_seconds: f64,
     /// Wall-clock time when this snapshot was last written.
     pub updated_at: DateTime<Utc>,
 }
@@ -86,6 +92,8 @@ impl Default for StellarMetricsSnapshot {
             ingestion_lag: 0,
             ledger_sequence: 0,
             active_connections: 0,
+            request_error_ratio: 0.0,
+            db_query_duration_seconds: 0.0,
             updated_at: Utc::now(),
         }
     }
@@ -228,6 +236,8 @@ mod tests {
             ingestion_lag: 1,
             ledger_sequence: 50_000_000,
             active_connections: 8,
+            request_error_ratio: 0.0,
+            db_query_duration_seconds: 0.0,
             updated_at: Utc::now(),
         }
     }


### PR DESCRIPTION
## Summary

- Adds `stellar_horizon_request_error_ratio` gauge: ratio (0.0–1.0) of Horizon API requests returning 4xx/5xx, derived by accumulating `horizon_requests_total{status_code=...}` lines from the `/metrics` scrape
- Adds `stellar_horizon_db_query_duration_seconds` gauge: average DB query duration in seconds, derived from `horizon_db_query_duration_seconds_sum / count` across all label combinations
- Extends `StellarMetricsSnapshot` with two new `f64` fields; all existing struct literal sites and `Default` impl are updated
- Calls new setter functions (`set_horizon_request_error_ratio`, `set_horizon_db_query_duration_seconds`) in the collector's `run()` loop under `#[cfg(feature = "metrics")]`
- Appends two new timeseries panels to `monitoring/grafana-horizon-dashboard.json` using the `stellar_*` metric names and the existing `$node` template variable
- Adds 4 unit tests covering the new parsing logic and zero-division guards

## Test plan

- [x] `cargo check` passes (dependencies compile)
- [x] `parse_prometheus_metrics` unit tests: error ratio (900/80/20 split → 0.1), zero-total guard, DB avg (2.0s / 400 queries → 0.005), zero-count guard
- [x] Existing tests (`test_parse_prometheus_metrics_basic`, `_with_labels`, `_missing_values`, `_float_truncation`) still pass
- [x] Dashboard JSON validated (9 panels, new panels at y=24)

Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)